### PR TITLE
Document Let, improve ParseError, propagate citations, spec amendments

### DIFF
--- a/docs/RAC_SPEC.md
+++ b/docs/RAC_SPEC.md
@@ -105,7 +105,9 @@ Path format: `title/section/subsection#variable_name`
 Expression-based — the last expression in a block is the value. No `return` keyword.
 
 - Conditionals: `if cond: expr elif cond: expr else: expr`
-- Let-bindings: `name = expr` (followed by body expression)
+- Let-bindings: `name = expr` (followed by body expression — the binding
+  is visible throughout the body; see the AST `Let` node docstring for
+  evaluation order and scoping rules)
 - Logic: `and`, `or`, `not`
 - Comparison: `<`, `<=`, `>`, `>=`, `==`, `!=`
 - Built-ins: `max`, `min`, `abs`, `round`, `sum`, `len`, `clip`, `any`, `all`

--- a/docs/amendment-precedence.md
+++ b/docs/amendment-precedence.md
@@ -1,0 +1,137 @@
+# Amendment precedence specification
+
+This document formalizes how rac resolves competing definitions for a
+single variable path across multiple source tiers. It is the reference
+for compiler behavior in `src/rac/compiler.py` (`TemporalLayer`,
+`_apply_amendments`, `_resolve_temporal`).
+
+## Source tiers
+
+A single variable (`path`) may be written or modified from several
+distinct source tiers. When two tiers cover the same effective date,
+higher-numbered tiers win:
+
+| Tier | Name          | Origin                                            | Produces                |
+|-----:|---------------|---------------------------------------------------|-------------------------|
+|    1 | Statute       | Statute encoding (`.rac` files in `rac-us/`, etc.) | `VariableDecl`          |
+|    2 | Projection    | Forecast / projection overlays for future periods | `AmendDecl` (by convention) |
+|    3 | Legislation   | Enacted legislation applying an amendment         | `AmendDecl`             |
+|    4 | Publication   | Published regulatory guidance / updated tables    | `AmendDecl`             |
+
+Numerically: **statute (1) < projection (2) < legislation (3) <
+publication (4)**. A publication-tier amendment overrides a
+legislation-tier amendment for the same effective date; a legislation-
+tier amendment overrides a projection; and so on.
+
+Tiers 2–4 are all expressed as `amend` declarations in rac today — the
+engine does not currently record the tier on the AST. The convention is
+that higher-tier amendments appear **later** in the module load order,
+because `TemporalLayer.resolve` applies the "later value wins" rule
+(`src/rac/compiler.py`, `TemporalLayer.resolve`). This is a load-order
+contract, not a parser-enforced invariant.
+
+## Resolution algorithm
+
+For a single variable path, resolution at a given `as_of` date proceeds:
+
+1. Collect all `TemporalValue` entries for the path, in module load
+   order. (Each `VariableDecl` and each `AmendDecl` contributes its
+   `values`.)
+2. Filter to entries that cover `as_of` (i.e. `start <= as_of` and
+   `end is None or as_of <= end`).
+3. Return the **last matching entry's expression**. "Last" is in
+   collection order, which matches declaration order within a module and
+   module order within the compiler's module list.
+4. If the variable has been repealed (`RepealDecl`) with
+   `effective <= as_of`, the variable is dropped from the resolved IR
+   entirely (the expression is `None` and the path is not present in
+   `Result.scalars` or `Result.entities`).
+
+## Tie-breaking rules
+
+When two or more temporal values cover the same `as_of` date:
+
+1. **Later source tier wins.** By convention, higher-tier amendments are
+   loaded later, so "later in the collected list" means "higher tier."
+2. **Within the same tier**, later declarations win. This lets a
+   statute file end with a corrective amendment that overrides earlier
+   values in the same file.
+3. **Replace-mode wins a whole segment.** An `AmendDecl` with
+   `replace: True` (`TemporalLayer.add_values(..., replace=True)`)
+   discards all previously accumulated values before adding its own.
+   This is the hammer — use it sparingly. Replace-mode is intended for
+   legislation that strikes and replaces an entire statutory provision
+   rather than amending it incrementally.
+4. **Repeal trumps everything.** If the path has been repealed with an
+   effective date at or before `as_of`, no amendment can bring it back.
+   A later "un-repeal" requires a fresh `VariableDecl` or a re-enactment
+   modeled as a new module.
+
+## Worked example
+
+Consider `gov/irs/ctc/base_amount` with these sources:
+
+```
+# statute/26/24.rac  (tier 1: statute)
+gov/irs/ctc/base_amount:
+    source: "26 USC 24(a)"
+    from 2018-01-01: 2000
+    from 2026-01-01: 1000   # statutory sunset back to pre-TCJA level
+
+# projections/ctc_projection.rac  (tier 2: projection)
+amend gov/irs/ctc/base_amount:
+    from 2026-01-01: 1050   # CBO-style inflation projection
+
+# legislation/obbba.rac  (tier 3: legislation)
+amend gov/irs/ctc/base_amount:
+    from 2026-01-01: 2200   # OBBBA sets CTC to $2,200 for 2026
+
+# publications/irs_rev_proc_2026.rac  (tier 4: publication)
+amend gov/irs/ctc/base_amount:
+    from 2026-01-01: 2225   # hypothetical inflation-indexed update
+```
+
+Resolution at `as_of = 2026-06-01`:
+
+| Step | Source                 | Contributes                     |
+|------|------------------------|---------------------------------|
+| 1    | statute                | `(2026-01-01, None) => 1000`    |
+| 2    | projection             | `(2026-01-01, None) => 1050`    |
+| 3    | legislation            | `(2026-01-01, None) => 2200`    |
+| 4    | publication            | `(2026-01-01, None) => 2225`    |
+
+All four match (`start <= 2026-06-01`, no end). The last collected
+entry wins → **2225**.
+
+If the publication module were removed, the result would be **2200**
+(legislation). If legislation were removed too, **1050** (projection).
+Without any amendments, **1000** (statute).
+
+Resolution at `as_of = 2024-06-01`:
+
+Only the statute's first segment (`from 2018-01-01: 2000`) matches. All
+three amendments are effective only from 2026-01-01, so they do not
+apply → **2000**.
+
+## Divergence from rac-compile
+
+`rac-compile` (the multi-target compiler) models amendments with a
+different `override:` keyword on variable declarations rather than a
+separate `amend` declaration. The two approaches are logically similar
+but differ in three ways:
+
+1. **Shape.** rac uses a separate `AmendDecl` node with its own
+   `target` path; rac-compile attaches `override:` to the original
+   variable declaration.
+2. **Tier tagging.** Neither system records the source tier on the AST
+   today; both rely on load order for precedence. A future change could
+   add an explicit `tier:` field to both.
+3. **Replace semantics.** rac's `replace: True` discards all prior
+   values; rac-compile's `override:` semantics are declaration-scoped
+   and the merge rule for multiple overrides of the same period is
+   currently unspecified.
+
+**These two models must be reconciled** before either can be treated as
+the canonical rac-ecosystem amendment form. This document tracks the
+rac engine's behavior; the rac-compile divergence is a known
+inconsistency flagged for a future RFC.

--- a/docs/citations.md
+++ b/docs/citations.md
@@ -1,0 +1,71 @@
+# Citation metadata propagation
+
+Every rac variable can carry a statutory citation via the `source:` metadata
+field. This document describes how that citation travels from the source
+`.rac` file through the parse → compile → execute pipeline, and the
+guarantees callers can rely on.
+
+## Surface syntax
+
+```
+gov/irs/standard_deduction:
+    source: "26 USC 63(c)"
+    label: "Standard deduction"
+    from 2024-01-01: 14600
+```
+
+`source` is a free-form string. The convention is a statutory citation
+("26 USC 32"), but the engine does not parse or validate the format —
+downstream tooling is free to interpret it.
+
+## Propagation contract
+
+The pipeline preserves `source` at every stage:
+
+1. **Parse** (`rac.parser`) — the string is stored on
+   `ast.VariableDecl.source`.
+2. **Compile** (`rac.compiler`) — `Compiler._collect_variables` copies it
+   onto `TemporalLayer`, and `_resolve_temporal` emits it on the
+   per-variable `ResolvedVar.source` in the produced `IR`.
+3. **Execute** (`rac.executor`) — `Executor.execute` populates
+   `Result.citations[path] = source` for every `ResolvedVar` that carries
+   a non-empty `source`. Variables without a citation are **omitted**
+   from the map (not set to `None` or `""`) to keep the map compact.
+
+```python
+result = run(ir, data)
+result.citations            # dict[str, str]: path -> citation
+result.citations.get("gov/rate")   # e.g. "26 USC 1"
+```
+
+## Amendments
+
+Amendments (`amend path:`) do not currently carry their own `source:`
+field. A variable's citation is the one declared on its original
+`VariableDecl`; amendments stack temporal values on top without
+overriding the citation. If a future change introduces a
+`source:` on `AmendDecl`, the intended semantics are that the amendment's
+citation applies only for dates it effectively covers — but that is a
+future extension, and today the original declaration's citation wins for
+all dates.
+
+## Repeals
+
+Repealed variables (`repeal`) drop out of the IR entirely for dates past
+the effective repeal, so they also drop out of `Result.citations`. This
+is consistent with the rest of the execution envelope.
+
+## Rust / native backend
+
+The Python executor is the canonical reference implementation for
+citation propagation. The Rust `CompiledBinary` path
+(`rac.native` / `rac.model.Model.run`) currently returns raw arrays and
+does not expose a `citations` map. Plumbing citations through the native
+backend is tracked as future work; callers that need citations today
+should use the Python executor (`rac.executor.run`).
+
+## Stability
+
+`Result.citations` is a stable field of the execution envelope. Adding
+new keys (as more statute files annotate `source:`) is backward
+compatible. Renaming or removing the field is not.

--- a/src/rac/ast.py
+++ b/src/rac/ast.py
@@ -68,7 +68,35 @@ class Cond(BaseModel):
 
 
 class Let(BaseModel):
-    """Let-binding: name = value, then body expression."""
+    """Let-binding: introduces a named value for use in a body expression.
+
+    Surface syntax (see docs/RAC_SPEC.md, "Expression syntax"):
+
+        name = value_expr
+        body_expr
+
+    Semantics:
+        1. ``value`` is evaluated first, in the surrounding environment
+           (``name`` is NOT yet in scope, so a Let cannot reference itself).
+        2. The resulting value is bound to ``name`` in the evaluation
+           context.
+        3. ``body`` is evaluated with ``name`` in scope and the Let node's
+           result is the result of ``body``.
+
+    Scope: the binding is visible throughout ``body``, including nested
+    Let-bindings. Nested Lets with the same ``name`` shadow the outer
+    binding for the duration of the inner body. In the current Python
+    executor the binding is written into the shared ``Context.computed``
+    dict, which means names leak after the Let body completes; callers
+    should treat Let as block-scoped and avoid relying on that leakage.
+
+    Evaluation order is strictly: value, then body. ``value`` is evaluated
+    exactly once per Let encounter (no lazy / call-by-name semantics).
+
+    Let is produced by :meth:`rac.parser.Parser.parse_expr` when it sees
+    the ``name = expr`` surface syntax; there is no ``let`` keyword in
+    the grammar.
+    """
 
     type: TypingLiteral["let"] = "let"
     name: str

--- a/src/rac/executor.py
+++ b/src/rac/executor.py
@@ -145,12 +145,23 @@ def evaluate(expr: ast.Expr, ctx: Context) -> Any:
 
 
 class Result(BaseModel):
-    """Execution result."""
+    """Execution result.
+
+    Attributes:
+        scalars: Computed scalar variables keyed by path.
+        entities: Per-entity computed columns: ``entities[entity][path]``
+            is the list of per-row values.
+        citations: Maps each computed variable path to its statutory
+            citation string (``source`` metadata on the declaration), if
+            one was provided. Variables with no citation are omitted.
+            See ``docs/citations.md`` for the propagation contract.
+    """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     scalars: dict[str, Any]
     entities: dict[str, dict[str, list[Any]]]
+    citations: dict[str, str] = {}
 
 
 class Executor:
@@ -162,9 +173,16 @@ class Executor:
     def execute(self, data: Data) -> Result:
         ctx = Context(data=data)
         entities: dict[str, dict[str, list[Any]]] = {}
+        citations: dict[str, str] = {}
 
         for path in self.ir.order:
             var = self.ir.variables[path]
+
+            # Propagate citation metadata onto the result envelope. Only
+            # variables that carry a ``source`` (statutory citation) are
+            # emitted; unannotated paths are omitted to keep the map tight.
+            if getattr(var, "source", None):
+                citations[path] = var.source
 
             if var.entity is None:
                 ctx.computed[path] = evaluate(var.expr, ctx)
@@ -188,7 +206,7 @@ class Executor:
                     ctx.current_row = None
                     ctx.current_entity = None
 
-        return Result(scalars=ctx.computed, entities=entities)
+        return Result(scalars=ctx.computed, entities=entities, citations=citations)
 
 
 def run(ir: IR, data: Data | dict[str, list[dict]]) -> Result:

--- a/src/rac/parser.py
+++ b/src/rac/parser.py
@@ -38,10 +38,45 @@ class Token:
 
 
 class ParseError(Exception):
-    def __init__(self, msg: str, line: int, col: int):
-        super().__init__(f"line {line}, col {col}: {msg}")
+    """Raised when lexing or parsing fails.
+
+    Attributes:
+        line: 1-indexed line number where the error was detected.
+        col: 1-indexed column number where the error was detected.
+        source_line: The offending source line (without trailing newline),
+            or ``None`` when the source text wasn't available at the raise
+            site. Used to render a caret-underlined message.
+
+    The formatted ``str(err)`` includes the source line and a caret
+    pointer under ``col`` when ``source_line`` is set; otherwise it falls
+    back to the original ``"line L, col C: msg"`` format.
+    """
+
+    def __init__(
+        self,
+        msg: str,
+        line: int,
+        col: int,
+        source_line: str | None = None,
+    ):
         self.line = line
         self.col = col
+        self.source_line = source_line
+        self.msg = msg
+        super().__init__(self._format())
+
+    def _format(self) -> str:
+        header = f"line {self.line}, col {self.col}: {self.msg}"
+        if not self.source_line:
+            return header
+        # Tabs throw off the caret offset; render them as a single space
+        # so the pointer lines up with a monospace display.
+        rendered = self.source_line.replace("\t", " ")
+        # col is 1-indexed; convert to 0-indexed offset and clamp into the
+        # rendered line so the caret always falls somewhere visible.
+        caret_offset = max(0, min(self.col - 1, len(rendered)))
+        pointer = " " * caret_offset + "^"
+        return f"{header}\n    {rendered}\n    {pointer}"
 
 
 class Lexer:
@@ -107,18 +142,26 @@ class Lexer:
         self.line = 1
         self.col = 1
         self.tokens: list[Token] = []
+        # Cache split lines for error reporting. Keep empty-string sentinel
+        # at index 0 so ``_lines[line]`` is a direct 1-indexed lookup.
+        self._lines: list[str] = [""] + source.splitlines()
         self._tokenise()
+
+    def _source_line(self, line: int) -> str | None:
+        if 1 <= line < len(self._lines):
+            return self._lines[line]
+        return None
 
     def _tokenise(self) -> None:
         while self.pos < len(self.source):
             # Skip triple-quoted text blocks (statute text in v2 .rac files)
-            if self.source[self.pos:self.pos + 3] == '"""':
+            if self.source[self.pos : self.pos + 3] == '"""':
                 end = self.source.find('"""', self.pos + 3)
                 if end == -1:
                     end = len(self.source)
                 else:
                     end += 3
-                skipped = self.source[self.pos:end]
+                skipped = self.source[self.pos : end]
                 for c in skipped:
                     if c == "\n":
                         self.line += 1
@@ -153,6 +196,7 @@ class Lexer:
                     f"unexpected char: {self.source[self.pos]!r}",
                     self.line,
                     self.col,
+                    source_line=self._source_line(self.line),
                 )
 
         self.tokens.append(Token("EOF", "", self.line, self.col))
@@ -163,14 +207,35 @@ class Parser:
 
     # Metadata field names allowed in definitions (v1 + v2 fields)
     METADATA_FIELDS = {
-        "source", "label", "description", "unit",
-        "dtype", "period", "default", "indexed_by",
+        "source",
+        "label",
+        "description",
+        "unit",
+        "dtype",
+        "period",
+        "default",
+        "indexed_by",
         "status",
     }
 
-    def __init__(self, tokens: list[Token]):
+    def __init__(
+        self,
+        tokens: list[Token],
+        source_lines: list[str] | None = None,
+    ):
         self.tokens = tokens
         self.pos = 0
+        # ``source_lines`` uses a sentinel at index 0 so ``[line]`` is a
+        # direct 1-indexed lookup, matching Lexer._lines.
+        self._source_lines = source_lines
+
+    def _source_line(self, line: int) -> str | None:
+        if self._source_lines and 1 <= line < len(self._source_lines):
+            return self._source_lines[line]
+        return None
+
+    def _error(self, msg: str, tok: Token) -> ParseError:
+        return ParseError(msg, tok.line, tok.col, source_line=self._source_line(tok.line))
 
     def peek(self, offset: int = 0) -> Token:
         idx = self.pos + offset
@@ -184,7 +249,7 @@ class Parser:
     def consume(self, ttype: str) -> Token:
         tok = self.peek()
         if tok.type != ttype:
-            raise ParseError(f"expected {ttype}, got {tok.type}", tok.line, tok.col)
+            raise self._error(f"expected {ttype}, got {tok.type} ({tok.value!r})", tok)
         self.pos += 1
         return tok
 
@@ -216,10 +281,15 @@ class Parser:
                     continue
                 # Skip enum declarations (e.g., "enum FilingStatus:")
                 if self.at("IDENT") and self.peek().value == "enum":
-                    while not self.at("EOF") and not (
-                        self.at("IDENT", "PATH") and self.peek(1).type == "COLON"
-                        and self.peek().value != "enum"
-                    ) and not self.at("ENTITY", "AMEND"):
+                    while (
+                        not self.at("EOF")
+                        and not (
+                            self.at("IDENT", "PATH")
+                            and self.peek(1).type == "COLON"
+                            and self.peek().value != "enum"
+                        )
+                        and not self.at("ENTITY", "AMEND")
+                    ):
                         self.pos += 1
                     continue
                 module.variables.append(self.parse_variable())
@@ -234,13 +304,16 @@ class Parser:
                 while not self.at("EOF"):
                     if self.at("ENTITY", "AMEND"):
                         break
-                    if (self.at("IDENT", "PATH") and self.peek(1).type == "COLON"
-                        and self.peek().value not in ("values",)):
+                    if (
+                        self.at("IDENT", "PATH")
+                        and self.peek(1).type == "COLON"
+                        and self.peek().value not in ("values",)
+                    ):
                         break
                     self.pos += 1
             else:
                 tok = self.peek()
-                raise ParseError(f"unexpected token: {tok.type}", tok.line, tok.col)
+                raise self._error(f"unexpected token: {tok.type} ({tok.value!r})", tok)
 
         return module
 
@@ -383,8 +456,7 @@ class Parser:
         """Parse expression, including let-bindings (name = value then body)."""
         # Check for let-binding: IDENT ASSIGN ...
         if (
-            self.at("IDENT")
-            and self.peek(1).type == "ASSIGN"
+            self.at("IDENT") and self.peek(1).type == "ASSIGN"
             # Make sure this isn't at the top level (metadata like `label = ...`)
             # by checking the IDENT isn't a metadata field followed by COLON
         ):
@@ -509,7 +581,7 @@ class Parser:
             if self.at("LPAREN"):
                 if not isinstance(expr, ast.Var):
                     tok = self.peek()
-                    raise ParseError("can only call named functions", tok.line, tok.col)
+                    raise self._error("can only call named functions", tok)
                 self.consume("LPAREN")
                 args = []
                 if not self.at("RPAREN"):
@@ -548,15 +620,13 @@ class Parser:
             return expr
 
         tok = self.peek()
-        raise ParseError(
-            f"unexpected token in expression: {tok.type}", tok.line, tok.col
-        )
+        raise self._error(f"unexpected token in expression: {tok.type} ({tok.value!r})", tok)
 
 
 def parse(source: str, path: str = "") -> ast.Module:
     """Parse .rac source code into an AST."""
     lexer = Lexer(source)
-    parser = Parser(lexer.tokens)
+    parser = Parser(lexer.tokens, source_lines=lexer._lines)
     return parser.parse_module(path)
 
 

--- a/tests/test_rac.py
+++ b/tests/test_rac.py
@@ -1211,6 +1211,116 @@ class TestParserCoverage:
             parser.consume("COLON")
 
 
+# -- Citation propagation ---------------------------------------------------
+
+
+class TestCitationPropagation:
+    """Statutory citations (``source:``) flow to Result.citations."""
+
+    def test_source_metadata_appears_in_result_citations(self):
+        from rac import parse
+        from rac.compiler import Compiler
+        from rac.executor import run
+
+        src = """
+            gov/rate:
+                source: "26 USC 1"
+                from 2024-01-01: 0.22
+
+            gov/base:
+                from 2024-01-01: 1000
+
+            gov/tax:
+                source: "26 USC 1(a)"
+                from 2024-01-01: gov/base * gov/rate
+        """
+        module = parse(src)
+        ir = Compiler([module]).compile(date(2024, 6, 1))
+        result = run(ir, {})
+        # Variables with source: are present in the citations map
+        assert result.citations.get("gov/rate") == "26 USC 1"
+        assert result.citations.get("gov/tax") == "26 USC 1(a)"
+        # Variables without source: are omitted
+        assert "gov/base" not in result.citations
+
+    def test_citations_absent_when_no_source_metadata(self):
+        from rac import parse
+        from rac.compiler import Compiler
+        from rac.executor import run
+
+        src = """
+            gov/rate:
+                from 2024-01-01: 0.22
+        """
+        module = parse(src)
+        ir = Compiler([module]).compile(date(2024, 1, 1))
+        result = run(ir, {})
+        assert result.citations == {}
+
+
+# -- ParseError formatting --------------------------------------------------
+
+
+class TestParseErrorContext:
+    """ParseError should render the offending source line with a caret."""
+
+    def test_error_includes_source_line_and_caret_for_missing_colon(self):
+        from rac import ParseError, parse
+
+        # Missing colon after the date; parser expects COLON before the expr.
+        src = "gov/rate:\n    from 2024-01-01 0.25\n"
+        with pytest.raises(ParseError) as exc_info:
+            parse(src)
+        err = exc_info.value
+        assert err.line == 2
+        # line/col still accessible (API stable)
+        assert isinstance(err.col, int)
+        text = str(err)
+        assert "expected COLON" in text
+        # Offending source line is included
+        assert "from 2024-01-01 0.25" in text
+        # Caret pointer is present on its own line
+        caret_lines = [ln for ln in text.splitlines() if ln.strip() == "^"]
+        assert caret_lines, f"no caret line in:\n{text}"
+
+    def test_error_caret_aligns_with_column(self):
+        from rac import ParseError, parse
+
+        # Missing colon before the expression: parser expects COLON after
+        # the date on line 2 and fails at the first non-COLON token.
+        src = "t:\n    from 2024-01-01 max(1, 2)\n"
+        with pytest.raises(ParseError) as exc_info:
+            parse(src)
+        err = exc_info.value
+        text = str(err)
+        assert "expected COLON" in text
+        lines = text.splitlines()
+        # The formatter indents the source line and caret with 4 spaces.
+        # The source line we're looking for contains "from 2024-01-01".
+        src_lines = [ln for ln in lines if ln.startswith("    ") and "from 2024-01-01" in ln]
+        caret_lines = [ln for ln in lines if ln.startswith("    ") and "^" in ln]
+        assert src_lines, f"no source line in:\n{text}"
+        assert caret_lines, f"no caret line in:\n{text}"
+        # caret offset within the rendered line (strip the 4-space prefix
+        # added by _format)
+        caret_offset = caret_lines[0][4:].index("^")
+        assert caret_offset == err.col - 1
+
+    def test_error_for_bad_identifier_at_top_level(self):
+        from rac import ParseError, parse
+
+        # Lexer rejects the '@' character (not a valid token start).
+        src = "ok:\n    from 2024-01-01: 1\n@bad\n"
+        with pytest.raises(ParseError) as exc_info:
+            parse(src)
+        err = exc_info.value
+        text = str(err)
+        assert err.line == 3
+        assert "@bad" in text
+        # unchanged attribute API
+        assert hasattr(err, "line") and hasattr(err, "col")
+
+
 # -- Additional executor coverage -------------------------------------------
 
 
@@ -1598,9 +1708,7 @@ class TestRustCodegenCoverage2:
         ir = IR(
             schema_=Schema(),
             variables={
-                "gov/x": ResolvedVar(
-                    path="gov/x", expr=UnaryOp(op="~", operand=Literal(value=1))
-                ),
+                "gov/x": ResolvedVar(path="gov/x", expr=UnaryOp(op="~", operand=Literal(value=1))),
             },
             order=["gov/x"],
         )
@@ -2013,11 +2121,7 @@ class TestModelCoverage:
         assert abs(gain[0] - 2500.0) < 0.01
 
     def test_compare_result_summary(self, tax_model, reform_model):
-        data = {
-            "person": [
-                {"id": i, "income": float(10000 + i * 10000)} for i in range(1, 21)
-            ]
-        }
+        data = {"person": [{"id": i, "income": float(10000 + i * 10000)} for i in range(1, 21)]}
         comparison = tax_model.compare(reform_model, data)
         summary = comparison.summary("person", "person/tax")
 
@@ -2030,11 +2134,7 @@ class TestModelCoverage:
     def test_compare_result_summary_with_income_deciles(self, tax_model, reform_model):
         import numpy as np
 
-        data = {
-            "person": [
-                {"id": i, "income": float(10000 + i * 10000)} for i in range(1, 101)
-            ]
-        }
+        data = {"person": [{"id": i, "income": float(10000 + i * 10000)} for i in range(1, 101)]}
         comparison = tax_model.compare(reform_model, data)
         income_col = np.array([10000 + i * 10000 for i in range(1, 101)], dtype=np.float64)
         summary = comparison.summary("person", "person/tax", income_col=income_col)
@@ -2168,7 +2268,7 @@ formula: |
         from rac.validate import validate_schema
 
         f = tmp_path / "test.rac"
-        f.write_text('label: test\n\"\"\"\nsome bad content\n\"\"\"\n')
+        f.write_text('label: test\n"""\nsome bad content\n"""\n')
         errors = validate_schema(tmp_path)
         assert errors == []
 
@@ -2564,9 +2664,7 @@ formula: |
             unittest.mock.patch(
                 "rac.validate._extract_imports", side_effect=ValueError("parse fail")
             ),
-            unittest.mock.patch(
-                "rac.validate._build_dependency_graph", return_value={}
-            ),
+            unittest.mock.patch("rac.validate._build_dependency_graph", return_value={}),
         ):
             from rac.validate import validate_imports
 


### PR DESCRIPTION
## Summary

Four concrete follow-ups from the review, each behind stable public APIs.

- **`ast.Let` docstring** — covers evaluation order (value before body, exactly once), block-scoping intent, shadowing semantics, and the "produced by `name = expr` surface form, not a `let` keyword" fact. `docs/RAC_SPEC.md` cross-references the AST docstring.
- **`ParseError` context** — now renders the offending source line with a caret under the column. `line`, `col`, and the exception class are unchanged. Added `source_line` and `msg` attributes. `Lexer` and `Parser` plumb source lines through every raise site.
- **Citation propagation** — `Result.citations: dict[str, str]` maps each computed variable path to its statutory `source:` citation. Variables without `source:` are omitted. See `docs/citations.md` for the full contract and the note on the Rust native-backend gap.
- **Amendment precedence spec** — `docs/amendment-precedence.md` formalizes statute < projection < legislation < publication, tie-breaking rules, replace/repeal semantics, a worked CTC example, and the divergence from rac-compile's `override:` model.

## Test plan

- [x] `TestParseErrorContext` (3 tests): missing-colon message, caret alignment, bad-char at lexer level.
- [x] `TestCitationPropagation` (2 tests): `source:` appears in `Result.citations`; absent when unannotated.
- [x] Full suite: 362 passed, 12 deselected.
  - 12 `TestNativeCoverage` tests deselected due to a pre-existing local Rust linker failure reproducible on `origin/main` (environment issue, unrelated to this PR).

## Out of scope

No grammar changes, no interpreter refactor, no parser consolidation with rac-compile.
