### PR TITLE
Fix amendment source override, tighten parser API and caret test

### DIFF
--- a/docs/amendment-precedence.md
+++ b/docs/amendment-precedence.md
@@ -71,6 +71,11 @@ When two or more temporal values cover the same `as_of` date:
 
 Consider `gov/irs/ctc/base_amount` with these sources:
 
+> **Note:** The $2,000 statute value and the $2,200 OBBBA legislation value
+> are real (26 USC 24 and the OBBBA as enacted). The $1,050 projection and
+> $2,225 publication values are illustrative — chosen to show tier
+> interleaving, not to represent actual CBO or IRS figures.
+
 ```
 # statute/26/24.rac  (tier 1: statute)
 gov/irs/ctc/base_amount:

--- a/src/rac/ast.py
+++ b/src/rac/ast.py
@@ -140,11 +140,15 @@ class AmendDecl(BaseModel):
     - Add new temporal periods
     - Override existing periods (later amendments win)
     - Completely replace a variable's formula
+    - Supply an updated citation that overrides the underlying statute's
+      ``source`` (e.g., a publication-tier amendment pointing at a
+      Revenue Procedure rather than the statutory section).
 
     This mirrors how legislation works: new laws amend existing statutes.
     """
 
     target: str  # path of variable being amended
+    source: str | None = None  # updated citation; overrides the layer's source when set
     values: list[TemporalValue] = []
     replace: bool = False  # if True, completely replaces (not merges) temporal values
 

--- a/src/rac/compiler.py
+++ b/src/rac/compiler.py
@@ -140,7 +140,14 @@ class Compiler:
         for amend in module.amendments:
             if amend.target not in self.layers:
                 self.layers[amend.target] = TemporalLayer(amend.target)
-            self.layers[amend.target].add_values(amend.values, replace=amend.replace)
+            layer = self.layers[amend.target]
+            layer.add_values(amend.values, replace=amend.replace)
+            # Publication-tier amendments can supply an updated citation
+            # (e.g., a Revenue Procedure) that should override the statute's
+            # source on the resolved variable. Only overwrite when the
+            # amendment explicitly provided a value.
+            if amend.source is not None:
+                layer.source = amend.source
 
     def _apply_repeals(self, module: ast.Module) -> None:
         for repeal in module.repeals:

--- a/src/rac/parser.py
+++ b/src/rac/parser.py
@@ -147,6 +147,16 @@ class Lexer:
         self._lines: list[str] = [""] + source.splitlines()
         self._tokenise()
 
+    @property
+    def source_lines(self) -> list[str]:
+        """Source lines indexed 1-based (index 0 is an empty sentinel).
+
+        Exposed as a stable public accessor so callers (notably
+        :func:`parse`) don't need to reach into the private ``_lines``
+        attribute to attach source context to :class:`ParseError`.
+        """
+        return self._lines
+
     def _source_line(self, line: int) -> str | None:
         if 1 <= line < len(self._lines):
             return self._lines[line]
@@ -418,12 +428,37 @@ class Parser:
         return ast.VariableDecl(path=path, entity=entity, values=values, **metadata)
 
     def parse_amend(self) -> ast.AmendDecl:
-        """Parse amendment declaration."""
+        """Parse amendment declaration.
+
+        Supports an optional ``source:`` metadata field before the temporal
+        values, allowing publication-tier amendments to override the
+        statutory citation attached to the original variable. Mirrors the
+        ``source:`` handling in :meth:`parse_variable`.
+        """
         self.consume("AMEND")
         target = self._parse_path()
         self.consume("COLON")
+
+        source: str | None = None
+        # Parse optional metadata (currently just ``source:``) before the
+        # temporal ``from`` blocks. We deliberately accept only the fields
+        # that amendments can meaningfully override today.
+        while self.at("IDENT") and self.peek().value == "source" and self.peek(1).type == "COLON":
+            self.consume("IDENT")  # "source"
+            self.consume("COLON")
+            tok = self.peek()
+            if tok.type == "STRING":
+                source = self.consume("STRING").value[1:-1]  # strip quotes
+            elif tok.type in ("IDENT", "INT", "FLOAT"):
+                source = self.consume(tok.type).value
+            else:
+                raise self._error(
+                    f"expected string literal for source, got {tok.type} ({tok.value!r})",
+                    tok,
+                )
+
         values = self._parse_temporal_values()
-        return ast.AmendDecl(target=target, values=values)
+        return ast.AmendDecl(target=target, source=source, values=values)
 
     def _parse_path(self) -> str:
         """Parse a path (either PATH token or IDENT)."""
@@ -626,7 +661,7 @@ class Parser:
 def parse(source: str, path: str = "") -> ast.Module:
     """Parse .rac source code into an AST."""
     lexer = Lexer(source)
-    parser = Parser(lexer.tokens, source_lines=lexer._lines)
+    parser = Parser(lexer.tokens, source_lines=lexer.source_lines)
     return parser.parse_module(path)
 
 

--- a/tests/test_rac.py
+++ b/tests/test_rac.py
@@ -1257,6 +1257,46 @@ class TestCitationPropagation:
         result = run(ir, {})
         assert result.citations == {}
 
+    def test_amendment_source_overrides_statutory_citation(self):
+        """Publication-tier amendments can override the statute's citation.
+
+        When a variable is defined with a statutory ``source:`` and a later
+        amendment supplies its own ``source:``, the resolved variable (and
+        therefore ``Result.citations``) must reflect the amendment's
+        citation for dates where the amendment is in effect. This is how
+        Rev. Proc. publication values supersede the base statute.
+
+        Note: the amendment's source overrides the layer's source whenever
+        the amendment module is loaded (it's a layer-level property, not a
+        temporal one). This is an acceptable simplification today — if we
+        ever need per-period source tracking, ``TemporalValue`` would need
+        its own ``source`` field. The important invariant this test pins
+        down is: a publication-tier citation does not get silently dropped
+        in favor of a stale statutory one.
+        """
+        from rac import parse
+        from rac.compiler import Compiler
+        from rac.executor import run
+
+        src = """
+            gov/ctc_amount:
+                source: "26 USC 24"
+                from 2024-01-01: 2000
+
+            amend gov/ctc_amount:
+                source: "Rev. Proc. 2026-42"
+                from 2026-01-01: 2200
+        """
+        module = parse(src)
+
+        # Evaluate on a date where the publication layer is effective and
+        # confirm the amendment's citation wins.
+        ir = Compiler([module]).compile(date(2026, 6, 1))
+        result = run(ir, {})
+        assert result.citations.get("gov/ctc_amount") == "Rev. Proc. 2026-42"
+        # And crucially, NOT the stale statutory citation.
+        assert result.citations.get("gov/ctc_amount") != "26 USC 24"
+
 
 # -- ParseError formatting --------------------------------------------------
 
@@ -1301,10 +1341,14 @@ class TestParseErrorContext:
         caret_lines = [ln for ln in lines if ln.startswith("    ") and "^" in ln]
         assert src_lines, f"no source line in:\n{text}"
         assert caret_lines, f"no caret line in:\n{text}"
-        # caret offset within the rendered line (strip the 4-space prefix
-        # added by _format)
-        caret_offset = caret_lines[0][4:].index("^")
-        assert caret_offset == err.col - 1
+        # Assert exact shape: the caret line is 4-space indent + (col-1)
+        # spaces + a single caret, with no trailing whitespace or extra
+        # carets. Using `.index("^")` would silently pass if the rendered
+        # source happened to contain its own `^`; this form prevents that.
+        expected_caret_line = "    " + " " * (err.col - 1) + "^"
+        assert caret_lines[0] == expected_caret_line, (
+            f"caret line {caret_lines[0]!r} != expected {expected_caret_line!r}"
+        )
 
     def test_error_for_bad_identifier_at_top_level(self):
         from rac import ParseError, parse


### PR DESCRIPTION
## Summary

Addresses actionable findings from the retroactive code review:

1. **Real bug — amendment `source:` override.** `AmendDecl` now carries an optional `source:` field. The parser accepts it before temporal values; the compiler overwrites the underlying `TemporalLayer.source` when an amendment supplies one. Without this, publication-tier amendments (e.g., a Rev. Proc. updating a statutory value) silently emit the stale statutory citation in `Result.citations`.
2. **API polish — public `Lexer.source_lines`.** Added a `@property` so `parse()` no longer reaches into the name-mangled `_lines`.
3. **Test robustness — caret alignment.** `test_error_caret_aligns_with_column` now asserts the exact caret-line shape (`"    " + " " * (col - 1) + "^"`) so a literal `^` in source can't mask a misalignment.
4. **Doc clarity.** Added a note to the worked example in `docs/amendment-precedence.md` clarifying which CTC values are real vs. illustrative.

Out of scope per the review: the multi-line triple-quoted token caret offset issue is deferred (requires deeper parser work, no user impact today).

## Test plan

- [x] `uv run pytest --deselect tests/test_rac.py::TestNativeCoverage` — 363 passed (was 362, +1 for the new `test_amendment_source_overrides_statutory_citation`)
- [x] `uvx ruff format` / `uvx ruff check` clean on all files touched

## Implementation note

The amendment's `source:` is a layer-level override (not per-`TemporalValue`), so once the amendment module is loaded the updated citation applies to the whole layer. Matches current design — if we later need per-period source tracking, `TemporalValue` itself would need a `source` field. Test docstring calls this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)