### PR TITLE
Add source registry validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e python/
-          python -m pip install pyyaml pydantic rich
+          python -m pip install pytest pyyaml pydantic rich
+
+      - name: Run Python tests
+        run: python -m pytest -q python/tests
 
       - name: Run all case runners
         run: python -m axiom_rules.cli check-examples

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Production rule content belongs in jurisdiction repositories where the filepath
 is the canonical ID. Source registries mirror the rule tree under `sources/`,
 store expected hashes in Git, and derive R2 artifact paths deterministically.
 
+To validate a jurisdiction repo's source registry files:
+
+```bash
+PYTHONPATH=python python3 -m axiom_rules.cli check-sources /path/to/us-tn
+```
+
 ## Python wrapper
 
 The thin Python wrapper lives under `python/axiom_rules/`. It exposes `Program`,

--- a/docs/jurisdiction-repos.md
+++ b/docs/jurisdiction-repos.md
@@ -123,6 +123,17 @@ stores expected hashes so a reviewed rule can prove which exact source artifacts
 it was reviewed against. Validation derives the R2 path, reads object metadata
 or bytes, and compares actual hashes to the Git-declared expected hashes.
 
+Validate registry files with:
+
+```bash
+PYTHONPATH=python python3 -m axiom_rules.cli check-sources /path/to/us-tn --verbose
+```
+
+The validator rejects duplicated `id:` fields, top-level `storage:` fields,
+missing expected hashes, non-taxonomy source paths, and non-absolute graph-edge
+targets. By default it derives source IDs from `<repo>:<sources-relative-path>`
+and R2 paths from `r2://axiom-sources/<repo>/<source-path>/<artifact>`.
+
 ## Artifact Overrides
 
 Use explicit artifact metadata only for exceptions:

--- a/python/axiom_rules/__init__.py
+++ b/python/axiom_rules/__init__.py
@@ -17,6 +17,18 @@ from .models import (
     QueryResult,
 )
 from .registry import ProgrammeEntry, ProgrammeRegistry
+from .source_registry import (
+    SourceArtifact,
+    SourceRegistryEntry,
+    SourceRegistryIssue,
+    SourceRegistryReport,
+    default_r2_path,
+    discover_source_files,
+    source_id_for,
+    source_path_for,
+    validate_source_registries,
+    validate_source_registry_file,
+)
 
 __all__ = [
     "CompiledExecutionRequest",
@@ -37,6 +49,16 @@ __all__ = [
     "ProgrammeEntry",
     "ProgrammeRegistry",
     "QueryResult",
+    "SourceArtifact",
+    "SourceRegistryEntry",
+    "SourceRegistryIssue",
+    "SourceRegistryReport",
     "AxiomRulesEngine",
+    "default_r2_path",
+    "discover_source_files",
     "load_program",
+    "source_id_for",
+    "source_path_for",
+    "validate_source_registries",
+    "validate_source_registry_file",
 ]

--- a/python/axiom_rules/cli.py
+++ b/python/axiom_rules/cli.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
+from .source_registry import validate_source_registries
+
 
 ROOT = Path(__file__).resolve().parents[2]
 EXAMPLES = ROOT / "python" / "examples"
@@ -84,6 +86,44 @@ def check_examples(args: argparse.Namespace) -> int:
     return 0
 
 
+def check_sources(args: argparse.Namespace) -> int:
+    roots = [Path(root) for root in args.roots]
+    if args.repo and len(roots) != 1:
+        print("--repo can only be used with one root", file=sys.stderr)
+        return 2
+
+    total_entries = 0
+    total_issues = 0
+    for root in roots:
+        report = validate_source_registries(
+            root,
+            repo=args.repo,
+            bucket=args.bucket,
+        )
+        total_entries += len(report.entries)
+        total_issues += len(report.issues)
+        if report.issues:
+            print(f"[FAIL] {root}")
+            for issue in report.issues:
+                try:
+                    issue_path = issue.path.relative_to(root.resolve())
+                except ValueError:
+                    issue_path = issue.path
+                print(f"  - {issue_path}: {issue.message}")
+        elif args.verbose:
+            print(f"[ok] {root}: {len(report.entries)} source registry file(s)")
+            for entry in report.entries:
+                print(f"  - {entry.source_id}")
+                for artifact in entry.artifacts:
+                    print(f"    {artifact.name}: {artifact.r2_path}")
+
+    if total_issues:
+        print(f"\nSource registry check failed with {total_issues} issue(s).")
+        return 1
+    print(f"\nValidated {total_entries} source registry file(s).")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m axiom_rules.cli")
     subcommands = parser.add_subparsers(dest="command", required=True)
@@ -108,6 +148,31 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print runner stdout/stderr even when the runner succeeds.",
     )
     check.set_defaults(func=check_examples)
+
+    sources = subcommands.add_parser(
+        "check-sources",
+        help="Validate jurisdiction-repo sources/**/*.yaml registry files.",
+    )
+    sources.add_argument(
+        "roots",
+        nargs="+",
+        help="Jurisdiction repository root(s) containing a sources/ tree.",
+    )
+    sources.add_argument(
+        "--repo",
+        help="Override the repo ID used for derived source IDs. Only valid with one root.",
+    )
+    sources.add_argument(
+        "--bucket",
+        default="axiom-sources",
+        help="R2 bucket name used when deriving default artifact paths.",
+    )
+    sources.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print derived source IDs and R2 paths for valid entries.",
+    )
+    sources.set_defaults(func=check_sources)
     return parser
 
 

--- a/python/axiom_rules/source_registry.py
+++ b/python/axiom_rules/source_registry.py
@@ -1,0 +1,463 @@
+"""Validation for jurisdiction-repo source registry files.
+
+Source registries live under ``sources/`` and mirror the executable rule tree.
+Their identity and default R2 object paths are derived from the repository name
+and filepath, so registry YAML should only store metadata and expected hashes.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+DEFAULT_BUCKET = "axiom-sources"
+DEFAULT_ARTIFACTS = ("raw", "akn", "text")
+HASH_KEYS = tuple(f"{artifact}_sha256" for artifact in DEFAULT_ARTIFACTS)
+EDGE_KEYS = ("sets", "implements", "extends", "authority")
+TAXONOMY_ROOTS = ("statute", "regulation", "policy")
+
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_ARTIFACT_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True)
+class SourceArtifact:
+    name: str
+    sha256: str
+    r2_path: str
+    media_type: str | None = None
+
+
+@dataclass(frozen=True)
+class SourceRegistryEntry:
+    path: Path
+    repo: str
+    source_path: str
+    source_id: str
+    artifacts: tuple[SourceArtifact, ...]
+
+
+@dataclass(frozen=True)
+class SourceRegistryIssue:
+    path: Path
+    message: str
+
+
+@dataclass(frozen=True)
+class SourceRegistryReport:
+    entries: tuple[SourceRegistryEntry, ...]
+    issues: tuple[SourceRegistryIssue, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.issues
+
+
+def discover_source_files(root: str | Path) -> list[Path]:
+    """Return all source-registry YAML files under ``root/sources``."""
+
+    root_path = Path(root)
+    sources_root = root_path / "sources"
+    if not sources_root.exists():
+        return []
+    files = [*sources_root.rglob("*.yaml"), *sources_root.rglob("*.yml")]
+    return sorted(path for path in files if path.is_file())
+
+
+def source_path_for(root: str | Path, source_file: str | Path) -> str:
+    """Derive the source identity path from a source-registry filepath."""
+
+    root_path = Path(root).resolve()
+    source_path = Path(source_file).resolve()
+    relative = source_path.relative_to(root_path / "sources")
+    return relative.with_suffix("").as_posix()
+
+
+def source_id_for(root: str | Path, source_file: str | Path, repo: str | None = None) -> str:
+    repo_name = repo or Path(root).resolve().name
+    return f"{repo_name}:{source_path_for(root, source_file)}"
+
+
+def default_r2_path(
+    *,
+    repo: str,
+    source_path: str,
+    artifact: str,
+    bucket: str = DEFAULT_BUCKET,
+) -> str:
+    return f"r2://{bucket}/{repo}/{source_path}/{artifact}"
+
+
+def validate_source_registries(
+    root: str | Path,
+    *,
+    repo: str | None = None,
+    bucket: str = DEFAULT_BUCKET,
+) -> SourceRegistryReport:
+    """Validate every source-registry YAML file under a jurisdiction repo root."""
+
+    root_path = Path(root).resolve()
+    repo_name = repo or root_path.name
+    issues: list[SourceRegistryIssue] = []
+    entries: list[SourceRegistryEntry] = []
+
+    if not root_path.exists():
+        return SourceRegistryReport(
+            (),
+            (SourceRegistryIssue(root_path, "jurisdiction repository root not found"),),
+        )
+    if not root_path.is_dir():
+        return SourceRegistryReport(
+            (),
+            (SourceRegistryIssue(root_path, "jurisdiction repository root must be a directory"),),
+        )
+
+    if not _REPO_RE.fullmatch(repo_name):
+        issues.append(
+            SourceRegistryIssue(
+                root_path,
+                f"repo name `{repo_name}` must match {_REPO_RE.pattern}",
+            )
+        )
+
+    for path in discover_source_files(root_path):
+        entry, file_issues = validate_source_registry_file(
+            root_path,
+            path,
+            repo=repo_name,
+            bucket=bucket,
+        )
+        issues.extend(file_issues)
+        if entry is not None:
+            entries.append(entry)
+
+    return SourceRegistryReport(tuple(entries), tuple(issues))
+
+
+def validate_source_registry_file(
+    root: str | Path,
+    path: str | Path,
+    *,
+    repo: str,
+    bucket: str = DEFAULT_BUCKET,
+) -> tuple[SourceRegistryEntry | None, list[SourceRegistryIssue]]:
+    root_path = Path(root).resolve()
+    source_file = Path(path).resolve()
+    issues: list[SourceRegistryIssue] = []
+
+    try:
+        source_path = source_path_for(root_path, source_file)
+    except ValueError:
+        return (
+            None,
+            [
+                SourceRegistryIssue(
+                    source_file,
+                    f"source registry file must live under {root_path / 'sources'}",
+                )
+            ],
+        )
+
+    first_segment = source_path.split("/", 1)[0]
+    if first_segment not in TAXONOMY_ROOTS:
+        issues.append(
+            SourceRegistryIssue(
+                source_file,
+                "source path must start with one of "
+                f"{', '.join(TAXONOMY_ROOTS)}; got `{first_segment}`",
+            )
+        )
+
+    try:
+        document = yaml.safe_load(source_file.read_text())
+    except yaml.YAMLError as error:
+        return (None, [SourceRegistryIssue(source_file, f"YAML parse error: {error}")])
+
+    if document is None:
+        document = {}
+    if not isinstance(document, dict):
+        return (
+            None,
+            [SourceRegistryIssue(source_file, "source registry YAML must be a mapping")],
+        )
+
+    _validate_required_metadata(source_file, document, issues)
+    _validate_forbidden_storage(source_file, document, issues)
+    _validate_edges(source_file, document, issues)
+
+    if "id" in document:
+        issues.append(
+            SourceRegistryIssue(
+                source_file,
+                "`id:` is redundant; source identity is derived from the filepath",
+            )
+        )
+    if "storage" in document:
+        issues.append(
+            SourceRegistryIssue(
+                source_file,
+                "`storage:` is redundant at top level; R2 paths are derived from the filepath",
+            )
+        )
+
+    artifacts = _validate_artifacts(
+        source_file,
+        document,
+        repo=repo,
+        source_path=source_path,
+        bucket=bucket,
+        issues=issues,
+    )
+
+    return (
+        SourceRegistryEntry(
+            path=source_file,
+            repo=repo,
+            source_path=source_path,
+            source_id=f"{repo}:{source_path}",
+            artifacts=tuple(artifacts),
+        ),
+        issues,
+    )
+
+
+def _validate_required_metadata(
+    path: Path,
+    document: dict[str, Any],
+    issues: list[SourceRegistryIssue],
+) -> None:
+    for field in ("publisher", "canonical_url", "retrieved_at"):
+        value = document.get(field)
+        if value is None or str(value).strip() == "":
+            issues.append(SourceRegistryIssue(path, f"`{field}:` is required"))
+
+
+def _validate_forbidden_storage(
+    path: Path,
+    value: Any,
+    issues: list[SourceRegistryIssue],
+    key_path: tuple[str, ...] = (),
+) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            next_path = (*key_path, str(key))
+            if key == "storage" and key_path and key_path[0] != "artifacts":
+                issues.append(
+                    SourceRegistryIssue(
+                        path,
+                        "`storage:` is only allowed inside explicit `artifacts:` overrides",
+                    )
+                )
+            _validate_forbidden_storage(path, child, issues, next_path)
+    elif isinstance(value, list):
+        for child in value:
+            _validate_forbidden_storage(path, child, issues, key_path)
+
+
+def _validate_edges(
+    path: Path,
+    document: dict[str, Any],
+    issues: list[SourceRegistryIssue],
+) -> None:
+    for key in EDGE_KEYS:
+        if key not in document:
+            continue
+        for target in _edge_targets(document[key]):
+            if not _is_absolute_canonical_path(target):
+                issues.append(
+                    SourceRegistryIssue(
+                        path,
+                        f"`{key}:` target `{target}` must be an absolute canonical path "
+                        "like `us:statute/7/2014/e/6/A`",
+                    )
+                )
+
+
+def _edge_targets(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, str):
+                yield item
+            else:
+                yield repr(item)
+    else:
+        yield repr(value)
+
+
+def _is_absolute_canonical_path(value: str) -> bool:
+    if "://" in value or value.endswith((".yaml", ".yml")):
+        return False
+    if ":" not in value:
+        return False
+    repo, path = value.split(":", 1)
+    if not _REPO_RE.fullmatch(repo):
+        return False
+    return any(path.startswith(f"{root}/") for root in TAXONOMY_ROOTS)
+
+
+def _validate_artifacts(
+    path: Path,
+    document: dict[str, Any],
+    *,
+    repo: str,
+    source_path: str,
+    bucket: str,
+    issues: list[SourceRegistryIssue],
+) -> list[SourceArtifact]:
+    if "artifacts" in document:
+        if "hashes" in document:
+            issues.append(
+                SourceRegistryIssue(
+                    path,
+                    "use either default `hashes:` or explicit `artifacts:`, not both",
+                )
+            )
+        return _validate_explicit_artifacts(
+            path,
+            document.get("artifacts"),
+            repo=repo,
+            source_path=source_path,
+            bucket=bucket,
+            issues=issues,
+        )
+    return _validate_default_hashes(
+        path,
+        document.get("hashes"),
+        repo=repo,
+        source_path=source_path,
+        bucket=bucket,
+        issues=issues,
+    )
+
+
+def _validate_default_hashes(
+    path: Path,
+    hashes: Any,
+    *,
+    repo: str,
+    source_path: str,
+    bucket: str,
+    issues: list[SourceRegistryIssue],
+) -> list[SourceArtifact]:
+    artifacts: list[SourceArtifact] = []
+    if not isinstance(hashes, dict):
+        issues.append(
+            SourceRegistryIssue(
+                path,
+                "`hashes:` mapping with raw_sha256, akn_sha256, and text_sha256 is required",
+            )
+        )
+        return artifacts
+
+    for artifact, key in zip(DEFAULT_ARTIFACTS, HASH_KEYS, strict=True):
+        sha = hashes.get(key)
+        if not _is_sha256(sha):
+            issues.append(
+                SourceRegistryIssue(path, f"`hashes.{key}` must be a SHA-256 hex digest")
+            )
+            continue
+        artifacts.append(
+            SourceArtifact(
+                name=artifact,
+                sha256=str(sha),
+                r2_path=default_r2_path(
+                    repo=repo,
+                    source_path=source_path,
+                    artifact=artifact,
+                    bucket=bucket,
+                ),
+            )
+        )
+    return artifacts
+
+
+def _validate_explicit_artifacts(
+    path: Path,
+    artifacts: Any,
+    *,
+    repo: str,
+    source_path: str,
+    bucket: str,
+    issues: list[SourceRegistryIssue],
+) -> list[SourceArtifact]:
+    parsed: list[SourceArtifact] = []
+    if not isinstance(artifacts, dict) or not artifacts:
+        issues.append(SourceRegistryIssue(path, "`artifacts:` must be a non-empty mapping"))
+        return parsed
+
+    for name, spec in artifacts.items():
+        artifact_name = str(name)
+        if not _ARTIFACT_NAME_RE.fullmatch(artifact_name):
+            issues.append(
+                SourceRegistryIssue(
+                    path,
+                    f"`artifacts.{artifact_name}` must use a simple artifact name",
+                )
+            )
+        if not isinstance(spec, dict):
+            issues.append(
+                SourceRegistryIssue(path, f"`artifacts.{artifact_name}` must be a mapping")
+            )
+            continue
+        sha = spec.get("sha256")
+        if not _is_sha256(sha):
+            issues.append(
+                SourceRegistryIssue(
+                    path,
+                    f"`artifacts.{artifact_name}.sha256` must be a SHA-256 hex digest",
+                )
+            )
+            continue
+        path_override = spec.get("path", spec.get("storage", artifact_name))
+        if not isinstance(path_override, str) or not path_override.strip():
+            issues.append(
+                SourceRegistryIssue(
+                    path,
+                    f"`artifacts.{artifact_name}.path` must be a non-empty relative path",
+                )
+            )
+            continue
+        if path_override.startswith("/") or ".." in Path(path_override).parts:
+            issues.append(
+                SourceRegistryIssue(
+                    path,
+                    f"`artifacts.{artifact_name}.path` must stay within the source identity path",
+                )
+            )
+            continue
+        r2_path = (
+            path_override
+            if path_override.startswith("r2://")
+            else default_r2_path(
+                repo=repo,
+                source_path=source_path,
+                artifact=path_override,
+                bucket=bucket,
+            )
+        )
+        parsed.append(
+            SourceArtifact(
+                name=artifact_name,
+                sha256=str(sha),
+                r2_path=r2_path,
+                media_type=_optional_string(spec.get("media_type")),
+            )
+        )
+    return parsed
+
+
+def _is_sha256(value: Any) -> bool:
+    return isinstance(value, str) and bool(_SHA256_RE.fullmatch(value))
+
+
+def _optional_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)

--- a/python/tests/test_source_registry.py
+++ b/python/tests/test_source_registry.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "python"))
+
+from axiom_rules.cli import main
+from axiom_rules.source_registry import (
+    default_r2_path,
+    discover_source_files,
+    source_id_for,
+    source_path_for,
+    validate_source_registries,
+)
+
+SHA_RAW = "a" * 64
+SHA_AKN = "b" * 64
+SHA_TEXT = "c" * 64
+
+
+def write_source(root: Path, relative: str, body: str) -> Path:
+    path = root / "sources" / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+def valid_default_body(extra: str = "") -> str:
+    return f"""
+publisher: Tennessee DHS
+canonical_url: https://example.test/manual
+retrieved_at: 2026-04-25T00:00:00Z
+hashes:
+  raw_sha256: {SHA_RAW}
+  akn_sha256: {SHA_AKN}
+  text_sha256: {SHA_TEXT}
+{extra}
+"""
+
+
+def test_derives_source_identity_and_default_r2_paths(tmp_path: Path) -> None:
+    root = tmp_path / "us-tn"
+    source = write_source(
+        root,
+        "policy/dhs/snap/manual/23/L.yaml",
+        valid_default_body(),
+    )
+
+    report = validate_source_registries(root)
+
+    assert report.ok
+    assert discover_source_files(root) == [source]
+    assert source_path_for(root, source) == "policy/dhs/snap/manual/23/L"
+    assert source_id_for(root, source) == "us-tn:policy/dhs/snap/manual/23/L"
+    entry = report.entries[0]
+    assert entry.source_id == "us-tn:policy/dhs/snap/manual/23/L"
+    assert [artifact.name for artifact in entry.artifacts] == ["raw", "akn", "text"]
+    assert [artifact.r2_path for artifact in entry.artifacts] == [
+        "r2://axiom-sources/us-tn/policy/dhs/snap/manual/23/L/raw",
+        "r2://axiom-sources/us-tn/policy/dhs/snap/manual/23/L/akn",
+        "r2://axiom-sources/us-tn/policy/dhs/snap/manual/23/L/text",
+    ]
+
+
+def test_repo_and_bucket_can_be_overridden(tmp_path: Path) -> None:
+    root = tmp_path / "checkout"
+    source = write_source(root, "regulation/7-cfr/273/9.yaml", valid_default_body())
+
+    report = validate_source_registries(root, repo="us", bucket="test-bucket")
+
+    assert report.ok
+    assert source_id_for(root, source, repo="us") == "us:regulation/7-cfr/273/9"
+    assert report.entries[0].artifacts[0].r2_path == (
+        "r2://test-bucket/us/regulation/7-cfr/273/9/raw"
+    )
+    assert default_r2_path(
+        repo="us",
+        source_path="regulation/7-cfr/273/9",
+        artifact="raw",
+        bucket="test-bucket",
+    ) == "r2://test-bucket/us/regulation/7-cfr/273/9/raw"
+
+
+def test_explicit_artifacts_replace_default_hashes(tmp_path: Path) -> None:
+    root = tmp_path / "us-tn"
+    write_source(
+        root,
+        "policy/dhs/snap/manual/23/L.yaml",
+        f"""
+publisher: Tennessee DHS
+canonical_url: https://example.test/manual
+retrieved_at: 2026-04-25T00:00:00Z
+artifacts:
+  raw:
+    path: manual.pdf
+    sha256: {SHA_RAW}
+    media_type: application/pdf
+  akn:
+    storage: akn.xml
+    sha256: {SHA_AKN}
+    media_type: application/akn+xml
+""",
+    )
+
+    report = validate_source_registries(root)
+
+    assert report.ok
+    assert [artifact.r2_path for artifact in report.entries[0].artifacts] == [
+        "r2://axiom-sources/us-tn/policy/dhs/snap/manual/23/L/manual.pdf",
+        "r2://axiom-sources/us-tn/policy/dhs/snap/manual/23/L/akn.xml",
+    ]
+
+
+def test_rejects_redundant_identity_storage_bad_hash_and_relative_edges(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "us-tn"
+    write_source(
+        root,
+        "policy/dhs/snap/manual/23/L.yaml",
+        """
+id: us-tn:policy/dhs/snap/manual/23/L
+publisher: Tennessee DHS
+canonical_url: https://example.test/manual
+retrieved_at: 2026-04-25T00:00:00Z
+storage: r2://axiom-sources/us-tn/policy/dhs/snap/manual/23/L
+sets:
+  - statute/7/2014/e/6/A
+hashes:
+  raw_sha256: not-a-hash
+  akn_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+""",
+    )
+
+    report = validate_source_registries(root)
+    messages = [issue.message for issue in report.issues]
+
+    assert not report.ok
+    assert any("`id:` is redundant" in message for message in messages)
+    assert any("`storage:` is redundant at top level" in message for message in messages)
+    assert any("`sets:` target" in message for message in messages)
+    assert any("hashes.raw_sha256" in message for message in messages)
+    assert any("hashes.text_sha256" in message for message in messages)
+
+
+def test_rejects_source_paths_outside_taxonomy(tmp_path: Path) -> None:
+    root = tmp_path / "us"
+    write_source(root, "other/manual.yaml", valid_default_body())
+
+    report = validate_source_registries(root)
+
+    assert not report.ok
+    assert any("source path must start with" in issue.message for issue in report.issues)
+
+
+def test_rejects_hashes_and_artifacts_together(tmp_path: Path) -> None:
+    root = tmp_path / "us"
+    write_source(
+        root,
+        "statute/7/2014/e/6/A.yaml",
+        valid_default_body(
+            extra=f"""
+artifacts:
+  raw:
+    path: raw.pdf
+    sha256: {SHA_RAW}
+"""
+        ),
+    )
+
+    report = validate_source_registries(root)
+
+    assert not report.ok
+    assert any("use either default `hashes:`" in issue.message for issue in report.issues)
+
+
+def test_missing_root_is_an_error(tmp_path: Path) -> None:
+    report = validate_source_registries(tmp_path / "missing")
+
+    assert not report.ok
+    assert report.issues[0].message == "jurisdiction repository root not found"
+
+
+def test_cli_check_sources_reports_failures(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "us"
+    write_source(
+        root,
+        "statute/7/2014/e/6/A.yaml",
+        """
+publisher: USDA
+canonical_url: https://example.test/statute
+retrieved_at: 2026-04-25T00:00:00Z
+hashes:
+  raw_sha256: bad
+""",
+    )
+
+    rc = main(["check-sources", str(root)])
+    captured = capsys.readouterr()
+
+    assert rc == 1
+    assert "[FAIL]" in captured.out
+    assert "Source registry check failed" in captured.out
+
+
+def test_cli_check_sources_verbose_success(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = tmp_path / "us"
+    write_source(root, "statute/7/2014/e/6/A.yaml", valid_default_body())
+
+    rc = main(["check-sources", str(root), "--verbose"])
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert "us:statute/7/2014/e/6/A" in captured.out
+    assert "Validated 1 source registry file" in captured.out


### PR DESCRIPTION
## Summary
- add a source-registry validator for jurisdiction repos under sources/**/*.yaml
- derive source IDs and default R2 paths from repo + filepath
- enforce metadata, expected hashes, no redundant top-level id/storage, taxonomy roots, and absolute graph-edge targets
- add check-sources CLI command and Python tests
- run Python tests in CI before example runners

## Verification
- cargo test
- python3 -m compileall -q python/axiom_rules python/examples
- PYTHONPATH=python python3 -m pytest -q python/tests
- PYTHONPATH=python python3 -m axiom_rules.cli check-examples
- PYTHONPATH=python python3 -m axiom_rules.cli check-sources . --verbose
- git diff --check