### PR TITLE
Verify source registry artifacts in R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ To validate a jurisdiction repo's source registry files:
 PYTHONPATH=python python3 -m axiom_rules.cli check-sources /path/to/us-tn
 ```
 
+Add `--verify-r2` with `AXIOM_R2_ACCOUNT_ID`, `AXIOM_R2_ACCESS_KEY_ID`, and
+`AXIOM_R2_SECRET_ACCESS_KEY` set to verify object existence and SHA-256 hashes
+against R2.
+
 ## Python wrapper
 
 The thin Python wrapper lives under `python/axiom_rules/`. It exposes `Program`,

--- a/docs/jurisdiction-repos.md
+++ b/docs/jurisdiction-repos.md
@@ -134,6 +134,19 @@ missing expected hashes, non-taxonomy source paths, and non-absolute graph-edge
 targets. By default it derives source IDs from `<repo>:<sources-relative-path>`
 and R2 paths from `r2://axiom-sources/<repo>/<source-path>/<artifact>`.
 
+To verify live R2 objects as well:
+
+```bash
+AXIOM_R2_ACCOUNT_ID=...
+AXIOM_R2_ACCESS_KEY_ID=...
+AXIOM_R2_SECRET_ACCESS_KEY=...
+PYTHONPATH=python python3 -m axiom_rules.cli check-sources /path/to/us-tn --verify-r2
+```
+
+`AXIOM_R2_ENDPOINT_URL` can be used instead of `AXIOM_R2_ACCOUNT_ID`. Live
+verification checks that each derived R2 object exists, streams its bytes, and
+compares the actual SHA-256 with the Git-declared expected hash.
+
 ## Artifact Overrides
 
 Use explicit artifact metadata only for exceptions:

--- a/python/axiom_rules/__init__.py
+++ b/python/axiom_rules/__init__.py
@@ -18,16 +18,20 @@ from .models import (
 )
 from .registry import ProgrammeEntry, ProgrammeRegistry
 from .source_registry import (
+    R2ObjectRef,
     SourceArtifact,
     SourceRegistryEntry,
     SourceRegistryIssue,
     SourceRegistryReport,
+    build_r2_client_from_env,
     default_r2_path,
     discover_source_files,
+    parse_r2_path,
     source_id_for,
     source_path_for,
     validate_source_registries,
     validate_source_registry_file,
+    verify_source_artifacts,
 )
 
 __all__ = [
@@ -49,16 +53,20 @@ __all__ = [
     "ProgrammeEntry",
     "ProgrammeRegistry",
     "QueryResult",
+    "R2ObjectRef",
     "SourceArtifact",
     "SourceRegistryEntry",
     "SourceRegistryIssue",
     "SourceRegistryReport",
     "AxiomRulesEngine",
+    "build_r2_client_from_env",
     "default_r2_path",
     "discover_source_files",
     "load_program",
+    "parse_r2_path",
     "source_id_for",
     "source_path_for",
     "validate_source_registries",
     "validate_source_registry_file",
+    "verify_source_artifacts",
 ]

--- a/python/axiom_rules/cli.py
+++ b/python/axiom_rules/cli.py
@@ -91,15 +91,19 @@ def check_sources(args: argparse.Namespace) -> int:
     if args.repo and len(roots) != 1:
         print("--repo can only be used with one root", file=sys.stderr)
         return 2
-
     total_entries = 0
     total_issues = 0
     for root in roots:
-        report = validate_source_registries(
-            root,
-            repo=args.repo,
-            bucket=args.bucket,
-        )
+        try:
+            report = validate_source_registries(
+                root,
+                repo=args.repo,
+                bucket=args.bucket,
+                verify_r2=args.verify_r2,
+            )
+        except RuntimeError as error:
+            print(error, file=sys.stderr)
+            return 2
         total_entries += len(report.entries)
         total_issues += len(report.issues)
         if report.issues:
@@ -171,6 +175,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help="Print derived source IDs and R2 paths for valid entries.",
+    )
+    sources.add_argument(
+        "--verify-r2",
+        action="store_true",
+        help="Fetch derived R2 objects and verify their SHA-256 hashes.",
     )
     sources.set_defaults(func=check_sources)
     return parser

--- a/python/axiom_rules/source_registry.py
+++ b/python/axiom_rules/source_registry.py
@@ -7,10 +7,12 @@ and filepath, so registry YAML should only store metadata and expected hashes.
 
 from __future__ import annotations
 
+import hashlib
+import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping, Protocol
 
 import yaml
 
@@ -58,6 +60,18 @@ class SourceRegistryReport:
         return not self.issues
 
 
+@dataclass(frozen=True)
+class R2ObjectRef:
+    bucket: str
+    key: str
+
+
+class R2Client(Protocol):
+    def head_object(self, *, Bucket: str, Key: str) -> Mapping[str, Any]: ...
+
+    def get_object(self, *, Bucket: str, Key: str) -> Mapping[str, Any]: ...
+
+
 def discover_source_files(root: str | Path) -> list[Path]:
     """Return all source-registry YAML files under ``root/sources``."""
 
@@ -93,11 +107,80 @@ def default_r2_path(
     return f"r2://{bucket}/{repo}/{source_path}/{artifact}"
 
 
+def parse_r2_path(path: str) -> R2ObjectRef:
+    if not path.startswith("r2://"):
+        raise ValueError(f"R2 path must start with `r2://`: {path}")
+    rest = path.removeprefix("r2://")
+    bucket, separator, key = rest.partition("/")
+    if not bucket or not separator or not key:
+        raise ValueError(f"R2 path must include bucket and object key: {path}")
+    return R2ObjectRef(bucket=bucket, key=key)
+
+
+def build_r2_client_from_env(env: Mapping[str, str] | None = None) -> R2Client:
+    """Build a Cloudflare R2 S3-compatible client from environment variables."""
+
+    values = env or os.environ
+    endpoint_url = values.get("AXIOM_R2_ENDPOINT_URL") or values.get(
+        "CLOUDFLARE_R2_ENDPOINT_URL"
+    )
+    account_id = (
+        values.get("AXIOM_R2_ACCOUNT_ID")
+        or values.get("CLOUDFLARE_R2_ACCOUNT_ID")
+        or values.get("CLOUDFLARE_ACCOUNT_ID")
+    )
+    if endpoint_url is None and account_id:
+        endpoint_url = f"https://{account_id}.r2.cloudflarestorage.com"
+
+    access_key_id = (
+        values.get("AXIOM_R2_ACCESS_KEY_ID")
+        or values.get("CLOUDFLARE_R2_ACCESS_KEY_ID")
+        or values.get("AWS_ACCESS_KEY_ID")
+    )
+    secret_access_key = (
+        values.get("AXIOM_R2_SECRET_ACCESS_KEY")
+        or values.get("CLOUDFLARE_R2_SECRET_ACCESS_KEY")
+        or values.get("AWS_SECRET_ACCESS_KEY")
+    )
+    missing = []
+    if endpoint_url is None:
+        missing.append("AXIOM_R2_ENDPOINT_URL or AXIOM_R2_ACCOUNT_ID")
+    if access_key_id is None:
+        missing.append("AXIOM_R2_ACCESS_KEY_ID")
+    if secret_access_key is None:
+        missing.append("AXIOM_R2_SECRET_ACCESS_KEY")
+    if missing:
+        raise RuntimeError(
+            "R2 verification requires " + ", ".join(missing) + " in the environment"
+        )
+
+    try:
+        import boto3
+    except ModuleNotFoundError as error:
+        raise RuntimeError(
+            "R2 verification requires boto3; install the Python package dependencies"
+        ) from error
+
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint_url,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+        aws_session_token=values.get("AXIOM_R2_SESSION_TOKEN")
+        or values.get("AWS_SESSION_TOKEN"),
+        region_name=values.get("AXIOM_R2_REGION")
+        or values.get("AWS_DEFAULT_REGION")
+        or "auto",
+    )
+
+
 def validate_source_registries(
     root: str | Path,
     *,
     repo: str | None = None,
     bucket: str = DEFAULT_BUCKET,
+    verify_r2: bool = False,
+    r2_client: R2Client | None = None,
 ) -> SourceRegistryReport:
     """Validate every source-registry YAML file under a jurisdiction repo root."""
 
@@ -125,7 +208,11 @@ def validate_source_registries(
             )
         )
 
-    for path in discover_source_files(root_path):
+    source_files = discover_source_files(root_path)
+    if verify_r2 and source_files and r2_client is None:
+        r2_client = build_r2_client_from_env()
+
+    for path in source_files:
         entry, file_issues = validate_source_registry_file(
             root_path,
             path,
@@ -135,8 +222,60 @@ def validate_source_registries(
         issues.extend(file_issues)
         if entry is not None:
             entries.append(entry)
+        if verify_r2 and r2_client is not None and entry is not None and not file_issues:
+            issues.extend(verify_source_artifacts(entry, r2_client))
 
     return SourceRegistryReport(tuple(entries), tuple(issues))
+
+
+def verify_source_artifacts(
+    entry: SourceRegistryEntry,
+    r2_client: R2Client,
+) -> list[SourceRegistryIssue]:
+    """Verify that derived R2 objects exist and match registry SHA-256 hashes."""
+
+    issues: list[SourceRegistryIssue] = []
+    for artifact in entry.artifacts:
+        try:
+            ref = parse_r2_path(artifact.r2_path)
+        except ValueError as error:
+            issues.append(SourceRegistryIssue(entry.path, str(error)))
+            continue
+
+        try:
+            r2_client.head_object(Bucket=ref.bucket, Key=ref.key)
+        except Exception as error:
+            issues.append(
+                SourceRegistryIssue(
+                    entry.path,
+                    f"R2 object `{artifact.r2_path}` is missing or inaccessible"
+                    f"{_format_exception_code(error)}",
+                )
+            )
+            continue
+
+        try:
+            response = r2_client.get_object(Bucket=ref.bucket, Key=ref.key)
+            actual_sha256 = _sha256_body(response.get("Body"))
+        except Exception as error:
+            issues.append(
+                SourceRegistryIssue(
+                    entry.path,
+                    f"failed to read R2 object `{artifact.r2_path}` for SHA-256 verification"
+                    f"{_format_exception_code(error)}",
+                )
+            )
+            continue
+
+        if actual_sha256.lower() != artifact.sha256.lower():
+            issues.append(
+                SourceRegistryIssue(
+                    entry.path,
+                    f"R2 object `{artifact.r2_path}` SHA-256 {actual_sha256} "
+                    f"does not match expected {artifact.sha256}",
+                )
+            )
+    return issues
 
 
 def validate_source_registry_file(
@@ -461,3 +600,60 @@ def _optional_string(value: Any) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+def _sha256_body(body: Any) -> str:
+    if body is None:
+        raise ValueError("R2 get_object response did not include a Body")
+    digest = hashlib.sha256()
+    try:
+        for chunk in _iter_body_chunks(body):
+            if chunk:
+                digest.update(chunk)
+    finally:
+        close = getattr(body, "close", None)
+        if close is not None:
+            close()
+    return digest.hexdigest()
+
+
+def _iter_body_chunks(body: Any) -> Iterable[bytes]:
+    if isinstance(body, bytes | bytearray):
+        yield bytes(body)
+        return
+
+    iter_chunks = getattr(body, "iter_chunks", None)
+    if iter_chunks is not None:
+        for chunk in iter_chunks(chunk_size=1024 * 1024):
+            yield _ensure_bytes(chunk)
+        return
+
+    read = getattr(body, "read", None)
+    if read is not None:
+        while True:
+            chunk = read(1024 * 1024)
+            if not chunk:
+                break
+            yield _ensure_bytes(chunk)
+        return
+
+    raise TypeError(f"unsupported R2 body type: {type(body).__name__}")
+
+
+def _ensure_bytes(chunk: Any) -> bytes:
+    if isinstance(chunk, bytes):
+        return chunk
+    if isinstance(chunk, bytearray):
+        return bytes(chunk)
+    if isinstance(chunk, str):
+        return chunk.encode()
+    raise TypeError(f"unsupported R2 body chunk type: {type(chunk).__name__}")
+
+
+def _format_exception_code(error: Exception) -> str:
+    response = getattr(error, "response", None)
+    if isinstance(response, dict):
+        code = response.get("Error", {}).get("Code")
+        if code:
+            return f" ({code})"
+    return f": {error}"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ name = "axiom-rules"
 version = "0.1.0"
 description = "Thin Python wrapper for the Axiom Rules Engine executable"
 requires-python = ">=3.11"
-dependencies = ["numpy>=2,<3", "pydantic>=2,<3", "PyYAML>=6,<7", "rich>=14,<15"]
+dependencies = ["boto3>=1,<2", "numpy>=2,<3", "pydantic>=2,<3", "PyYAML>=6,<7", "rich>=14,<15"]
 
 [project.scripts]
 axiom-rules-py = "axiom_rules.cli:main"

--- a/python/tests/test_source_registry.py
+++ b/python/tests/test_source_registry.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -10,8 +12,11 @@ sys.path.insert(0, str(ROOT / "python"))
 
 from axiom_rules.cli import main
 from axiom_rules.source_registry import (
+    R2ObjectRef,
+    build_r2_client_from_env,
     default_r2_path,
     discover_source_files,
+    parse_r2_path,
     source_id_for,
     source_path_for,
     validate_source_registries,
@@ -20,6 +25,46 @@ from axiom_rules.source_registry import (
 SHA_RAW = "a" * 64
 SHA_AKN = "b" * 64
 SHA_TEXT = "c" * 64
+
+
+class FakeBody:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.offset = 0
+        self.closed = False
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self.data) - self.offset
+        chunk = self.data[self.offset : self.offset + size]
+        self.offset += len(chunk)
+        return chunk
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeR2Error(Exception):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+class FakeR2Client:
+    def __init__(self, objects: dict[tuple[str, str], bytes]) -> None:
+        self.objects = objects
+
+    def head_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        if (Bucket, Key) not in self.objects:
+            raise FakeR2Error("NoSuchKey")
+        return {}
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, Any]:
+        try:
+            data = self.objects[(Bucket, Key)]
+        except KeyError as error:
+            raise FakeR2Error("NoSuchKey") from error
+        return {"Body": FakeBody(data)}
 
 
 def write_source(root: Path, relative: str, body: str) -> Path:
@@ -38,6 +83,19 @@ hashes:
   raw_sha256: {SHA_RAW}
   akn_sha256: {SHA_AKN}
   text_sha256: {SHA_TEXT}
+{extra}
+"""
+
+
+def body_with_hashes(*, raw: bytes, akn: bytes, text: bytes, extra: str = "") -> str:
+    return f"""
+publisher: Tennessee DHS
+canonical_url: https://example.test/manual
+retrieved_at: 2026-04-25T00:00:00Z
+hashes:
+  raw_sha256: {hashlib.sha256(raw).hexdigest()}
+  akn_sha256: {hashlib.sha256(akn).hexdigest()}
+  text_sha256: {hashlib.sha256(text).hexdigest()}
 {extra}
 """
 
@@ -83,6 +141,15 @@ def test_repo_and_bucket_can_be_overridden(tmp_path: Path) -> None:
         artifact="raw",
         bucket="test-bucket",
     ) == "r2://test-bucket/us/regulation/7-cfr/273/9/raw"
+
+
+def test_parse_r2_path() -> None:
+    assert parse_r2_path("r2://axiom-sources/us/foo/raw") == R2ObjectRef(
+        bucket="axiom-sources",
+        key="us/foo/raw",
+    )
+    with pytest.raises(ValueError):
+        parse_r2_path("https://example.test/us/foo/raw")
 
 
 def test_explicit_artifacts_replace_default_hashes(tmp_path: Path) -> None:
@@ -178,6 +245,81 @@ artifacts:
     assert any("use either default `hashes:`" in issue.message for issue in report.issues)
 
 
+def test_verify_r2_accepts_matching_objects(tmp_path: Path) -> None:
+    root = tmp_path / "us-tn"
+    raw = b"raw pdf bytes"
+    akn = b"<akomaNtoso />"
+    text = b"manual text"
+    write_source(
+        root,
+        "policy/dhs/snap/manual/23/L.yaml",
+        body_with_hashes(raw=raw, akn=akn, text=text),
+    )
+    client = FakeR2Client(
+        {
+            ("axiom-sources", "us-tn/policy/dhs/snap/manual/23/L/raw"): raw,
+            ("axiom-sources", "us-tn/policy/dhs/snap/manual/23/L/akn"): akn,
+            ("axiom-sources", "us-tn/policy/dhs/snap/manual/23/L/text"): text,
+        }
+    )
+
+    report = validate_source_registries(root, verify_r2=True, r2_client=client)
+
+    assert report.ok
+
+
+def test_verify_r2_reports_missing_and_hash_mismatch(tmp_path: Path) -> None:
+    root = tmp_path / "us-tn"
+    raw = b"expected raw"
+    akn = b"expected akn"
+    text = b"expected text"
+    write_source(
+        root,
+        "policy/dhs/snap/manual/23/L.yaml",
+        body_with_hashes(raw=raw, akn=akn, text=text),
+    )
+    client = FakeR2Client(
+        {
+            ("axiom-sources", "us-tn/policy/dhs/snap/manual/23/L/raw"): b"wrong raw",
+            ("axiom-sources", "us-tn/policy/dhs/snap/manual/23/L/akn"): akn,
+        }
+    )
+
+    report = validate_source_registries(root, verify_r2=True, r2_client=client)
+    messages = [issue.message for issue in report.issues]
+
+    assert not report.ok
+    assert any("SHA-256" in message and "does not match" in message for message in messages)
+    assert any("text` is missing or inaccessible" in message for message in messages)
+
+
+def test_verify_r2_requires_client_or_environment(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "us"
+    write_source(root, "statute/7/2014/e/6/A.yaml", valid_default_body())
+    for name in (
+        "AXIOM_R2_ENDPOINT_URL",
+        "AXIOM_R2_ACCOUNT_ID",
+        "CLOUDFLARE_R2_ENDPOINT_URL",
+        "CLOUDFLARE_R2_ACCOUNT_ID",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "AXIOM_R2_ACCESS_KEY_ID",
+        "CLOUDFLARE_R2_ACCESS_KEY_ID",
+        "AWS_ACCESS_KEY_ID",
+        "AXIOM_R2_SECRET_ACCESS_KEY",
+        "CLOUDFLARE_R2_SECRET_ACCESS_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    with pytest.raises(RuntimeError, match="R2 verification requires"):
+        validate_source_registries(root, verify_r2=True)
+
+
+def test_build_r2_client_from_env_reports_missing_values() -> None:
+    with pytest.raises(RuntimeError, match="AXIOM_R2_ENDPOINT_URL"):
+        build_r2_client_from_env({})
+
+
 def test_missing_root_is_an_error(tmp_path: Path) -> None:
     report = validate_source_registries(tmp_path / "missing")
 
@@ -223,3 +365,32 @@ def test_cli_check_sources_verbose_success(
     assert rc == 0
     assert "us:statute/7/2014/e/6/A" in captured.out
     assert "Validated 1 source registry file" in captured.out
+
+
+def test_cli_check_sources_verify_r2_reports_missing_config(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "us"
+    write_source(root, "statute/7/2014/e/6/A.yaml", valid_default_body())
+    for name in (
+        "AXIOM_R2_ENDPOINT_URL",
+        "AXIOM_R2_ACCOUNT_ID",
+        "CLOUDFLARE_R2_ENDPOINT_URL",
+        "CLOUDFLARE_R2_ACCOUNT_ID",
+        "CLOUDFLARE_ACCOUNT_ID",
+        "AXIOM_R2_ACCESS_KEY_ID",
+        "CLOUDFLARE_R2_ACCESS_KEY_ID",
+        "AWS_ACCESS_KEY_ID",
+        "AXIOM_R2_SECRET_ACCESS_KEY",
+        "CLOUDFLARE_R2_SECRET_ACCESS_KEY",
+        "AWS_SECRET_ACCESS_KEY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+    rc = main(["check-sources", str(root), "--verify-r2"])
+    captured = capsys.readouterr()
+
+    assert rc == 2
+    assert "R2 verification requires" in captured.err


### PR DESCRIPTION
## Summary
- add optional --verify-r2 mode for check-sources
- build a Cloudflare R2 S3-compatible client from AXIOM_R2_* / Cloudflare / AWS-compatible env vars
- parse derived r2:// paths, check object existence, stream object bytes, and compare actual SHA-256 against Git-declared hashes
- add fake-client tests for matching objects, missing objects, mismatches, invalid R2 paths, and missing config
- document live verification env vars and add boto3 to the Python package dependencies

## Verification
- cargo test
- python3 -m compileall -q python/axiom_rules python/examples
- PYTHONPATH=python python3 -m pytest -q python/tests
- PYTHONPATH=python python3 -m axiom_rules.cli check-examples
- PYTHONPATH=python python3 -m axiom_rules.cli check-sources . --verify-r2 --verbose
- git diff --check