### PR TITLE
Namespace RuleSpec data relations

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -263,21 +263,52 @@ impl<'a> Lexer<'a> {
             // String literal
             if c == b'"' || c == b'\'' {
                 let quote = c;
-                let start = self.pos + 1;
-                let mut end = start;
-                while end < self.src.len() && self.src[end] != quote {
-                    end += 1;
+                self.advance(1);
+                let mut value = String::new();
+                let mut segment_start = self.pos;
+                while self.pos < self.src.len() {
+                    let current = self.src[self.pos];
+                    if current == quote {
+                        if segment_start < self.pos {
+                            value.push_str(
+                                std::str::from_utf8(&self.src[segment_start..self.pos]).unwrap(),
+                            );
+                        }
+                        self.advance(1);
+                        self.push(TokType::String, value, line, col);
+                        break;
+                    }
+                    if current == b'\\' {
+                        if segment_start < self.pos {
+                            value.push_str(
+                                std::str::from_utf8(&self.src[segment_start..self.pos]).unwrap(),
+                            );
+                        }
+                        if self.pos + 1 >= self.src.len() {
+                            return Err(FormulaError::parse(line, col, "unterminated string"));
+                        }
+                        let escaped = self.src[self.pos + 1];
+                        value.push(match escaped {
+                            b'\\' => '\\',
+                            b'"' => '"',
+                            b'\'' => '\'',
+                            b'n' => '\n',
+                            b'r' => '\r',
+                            b't' => '\t',
+                            other => other as char,
+                        });
+                        self.advance(2);
+                        segment_start = self.pos;
+                        continue;
+                    }
+                    self.advance(1);
                 }
-                if end >= self.src.len() {
-                    return Err(FormulaError::parse(line, col, "unterminated string"));
+                if self.tokens.last().is_some_and(|token| {
+                    token.ty == TokType::String && token.line == line && token.col == col
+                }) {
+                    continue;
                 }
-                let s = std::str::from_utf8(&self.src[start..end])
-                    .unwrap()
-                    .to_string();
-                let n = end + 1 - self.pos;
-                self.advance(n);
-                self.push(TokType::String, s, line, col);
-                continue;
+                return Err(FormulaError::parse(line, col, "unterminated string"));
             }
 
             // Identifier / path / keyword

--- a/src/model.rs
+++ b/src/model.rs
@@ -372,6 +372,9 @@ impl Program {
     }
 
     pub fn resolve_relation_name(&self, reference: &str) -> Option<String> {
+        if self.relations.contains_key(reference) {
+            return Some(reference.to_string());
+        }
         if !self.has_public_ids() {
             return self
                 .relations

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -8,8 +8,8 @@ use serde::Deserialize;
 use thiserror::Error;
 
 use crate::spec::{
-    IndexedParameterSpec, ParameterVersionSpec, ProgramSpec, RelationSpec, ScalarValueSpec,
-    UnitSpec,
+    DerivedSemanticsSpec, IndexedParameterSpec, JudgmentExprSpec, ParameterVersionSpec,
+    ProgramSpec, RelationSpec, ScalarExprSpec, ScalarValueSpec, UnitSpec,
 };
 
 #[derive(Debug, Error)]
@@ -583,6 +583,7 @@ impl RulesDocument {
         self.write_header(&mut formula_source);
 
         let mut explicit_relations = Vec::new();
+        let mut relation_rewrites = HashMap::new();
         let mut table_parameters = Vec::new();
         let mut table_parameter_names = HashSet::new();
         for rule in &self.rules {
@@ -614,7 +615,16 @@ impl RulesDocument {
                 }
                 RuleKind::DataRelation => {
                     rule.reject_top_level_arity()?;
-                    explicit_relations.push(rule.to_data_relation_spec()?);
+                    let relation = rule.to_data_relation_spec()?;
+                    if relation.name != rule.name {
+                        if let Some(origin_target) = rule.origin_target.as_deref() {
+                            relation_rewrites.insert(
+                                (origin_target.to_string(), rule.name.clone()),
+                                relation.name.clone(),
+                            );
+                        }
+                    }
+                    explicit_relations.push(relation);
                 }
                 RuleKind::SourceRelation => {
                     rule.reject_top_level_arity()?;
@@ -635,6 +645,7 @@ impl RulesDocument {
             program.parameters.extend(table_parameters);
         }
         self.apply_rule_ids(&mut program);
+        rewrite_relation_references(&mut program, &relation_rewrites);
         append_missing_units(&mut program, &self.units);
         append_missing_relations(&mut program, &explicit_relations)?;
         Ok(program)
@@ -695,6 +706,13 @@ impl RuleDefinition {
         self.origin_target
             .as_ref()
             .map(|target| format!("{target}#{}", self.name))
+    }
+
+    fn canonical_relation_id(&self) -> String {
+        self.origin_target
+            .as_ref()
+            .map(|target| format!("{target}#relation.{}", self.name))
+            .unwrap_or_else(|| self.name.clone())
     }
 
     fn declared_kind(&self) -> Result<RuleKind, RuleSpecError> {
@@ -781,7 +799,7 @@ impl RuleDefinition {
                 name: self.name.clone(),
             })?;
         Ok(RelationSpec {
-            name: self.name.clone(),
+            name: self.canonical_relation_id(),
             arity,
         })
     }
@@ -1055,6 +1073,141 @@ fn append_missing_relations(
         program.relations.push(relation.clone());
     }
     Ok(())
+}
+
+fn rewrite_relation_references(
+    program: &mut ProgramSpec,
+    rewrites: &HashMap<(String, String), String>,
+) {
+    if rewrites.is_empty() {
+        return;
+    }
+    let namespaced_short_names: HashSet<String> = rewrites
+        .keys()
+        .map(|(_, relation)| relation.clone())
+        .collect();
+    for derived in &mut program.derived {
+        let Some(origin_target) = derived
+            .id
+            .as_deref()
+            .and_then(|id| id.split_once('#').map(|(target, _)| target))
+        else {
+            continue;
+        };
+        match &mut derived.semantics {
+            DerivedSemanticsSpec::Scalar { expr } => {
+                rewrite_scalar_relation_references(expr, origin_target, rewrites);
+            }
+            DerivedSemanticsSpec::Judgment { expr } => {
+                rewrite_judgment_relation_references(expr, origin_target, rewrites);
+            }
+        }
+    }
+    program
+        .relations
+        .retain(|relation| !namespaced_short_names.contains(&relation.name));
+}
+
+fn rewrite_scalar_relation_references(
+    expr: &mut ScalarExprSpec,
+    origin_target: &str,
+    rewrites: &HashMap<(String, String), String>,
+) {
+    match expr {
+        ScalarExprSpec::Literal { .. }
+        | ScalarExprSpec::Input { .. }
+        | ScalarExprSpec::Derived { .. }
+        | ScalarExprSpec::PeriodStart
+        | ScalarExprSpec::PeriodEnd => {}
+        ScalarExprSpec::InputOrElse { default: _, .. } => {}
+        ScalarExprSpec::ParameterLookup { index, .. }
+        | ScalarExprSpec::Ceil { value: index }
+        | ScalarExprSpec::Floor { value: index } => {
+            rewrite_scalar_relation_references(index, origin_target, rewrites);
+        }
+        ScalarExprSpec::Add { items }
+        | ScalarExprSpec::Max { items }
+        | ScalarExprSpec::Min { items } => {
+            for item in items {
+                rewrite_scalar_relation_references(item, origin_target, rewrites);
+            }
+        }
+        ScalarExprSpec::Sub { left, right }
+        | ScalarExprSpec::Mul { left, right }
+        | ScalarExprSpec::Div { left, right } => {
+            rewrite_scalar_relation_references(left, origin_target, rewrites);
+            rewrite_scalar_relation_references(right, origin_target, rewrites);
+        }
+        ScalarExprSpec::DateAddDays { date, days } => {
+            rewrite_scalar_relation_references(date, origin_target, rewrites);
+            rewrite_scalar_relation_references(days, origin_target, rewrites);
+        }
+        ScalarExprSpec::DaysBetween { from, to } => {
+            rewrite_scalar_relation_references(from, origin_target, rewrites);
+            rewrite_scalar_relation_references(to, origin_target, rewrites);
+        }
+        ScalarExprSpec::CountRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            rewrite_relation_name(relation, origin_target, rewrites);
+            if let Some(where_clause) = where_clause {
+                rewrite_judgment_relation_references(where_clause, origin_target, rewrites);
+            }
+        }
+        ScalarExprSpec::SumRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            rewrite_relation_name(relation, origin_target, rewrites);
+            if let Some(where_clause) = where_clause {
+                rewrite_judgment_relation_references(where_clause, origin_target, rewrites);
+            }
+        }
+        ScalarExprSpec::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            rewrite_judgment_relation_references(condition, origin_target, rewrites);
+            rewrite_scalar_relation_references(then_expr, origin_target, rewrites);
+            rewrite_scalar_relation_references(else_expr, origin_target, rewrites);
+        }
+    }
+}
+
+fn rewrite_judgment_relation_references(
+    expr: &mut JudgmentExprSpec,
+    origin_target: &str,
+    rewrites: &HashMap<(String, String), String>,
+) {
+    match expr {
+        JudgmentExprSpec::Comparison { left, right, .. } => {
+            rewrite_scalar_relation_references(left, origin_target, rewrites);
+            rewrite_scalar_relation_references(right, origin_target, rewrites);
+        }
+        JudgmentExprSpec::Derived { .. } => {}
+        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+            for item in items {
+                rewrite_judgment_relation_references(item, origin_target, rewrites);
+            }
+        }
+        JudgmentExprSpec::Not { item } => {
+            rewrite_judgment_relation_references(item, origin_target, rewrites);
+        }
+    }
+}
+
+fn rewrite_relation_name(
+    relation: &mut String,
+    origin_target: &str,
+    rewrites: &HashMap<(String, String), String>,
+) {
+    if let Some(rewrite) = rewrites.get(&(origin_target.to_string(), relation.clone())) {
+        *relation = rewrite.clone();
+    }
 }
 
 fn write_metadata(out: &mut String, key: &str, value: Option<&str>) {

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -645,7 +645,7 @@ impl RulesDocument {
             program.parameters.extend(table_parameters);
         }
         self.apply_rule_ids(&mut program);
-        rewrite_relation_references(&mut program, &relation_rewrites);
+        rewrite_relation_references(&mut program, &relation_rewrites, &explicit_relations)?;
         append_missing_units(&mut program, &self.units);
         append_missing_relations(&mut program, &explicit_relations)?;
         Ok(program)
@@ -1078,9 +1078,34 @@ fn append_missing_relations(
 fn rewrite_relation_references(
     program: &mut ProgramSpec,
     rewrites: &HashMap<(String, String), String>,
-) {
+    explicit_relations: &[RelationSpec],
+) -> Result<(), RuleSpecError> {
     if rewrites.is_empty() {
-        return;
+        return Ok(());
+    }
+    let inferred_arities: HashMap<String, usize> = program
+        .relations
+        .iter()
+        .map(|relation| (relation.name.clone(), relation.arity))
+        .collect();
+    let explicit_arities: HashMap<String, usize> = explicit_relations
+        .iter()
+        .map(|relation| (relation.name.clone(), relation.arity))
+        .collect();
+    for ((_, short_name), canonical_name) in rewrites {
+        let Some(inferred_arity) = inferred_arities.get(short_name) else {
+            continue;
+        };
+        let Some(explicit_arity) = explicit_arities.get(canonical_name) else {
+            continue;
+        };
+        if inferred_arity != explicit_arity {
+            return Err(RuleSpecError::RelationArityConflict {
+                name: canonical_name.clone(),
+                existing: *inferred_arity,
+                new: *explicit_arity,
+            });
+        }
     }
     let namespaced_short_names: HashSet<String> = rewrites
         .keys()
@@ -1103,9 +1128,110 @@ fn rewrite_relation_references(
             }
         }
     }
-    program
-        .relations
-        .retain(|relation| !namespaced_short_names.contains(&relation.name));
+    let used_relations = used_relation_names(program);
+    program.relations.retain(|relation| {
+        !namespaced_short_names.contains(&relation.name) || used_relations.contains(&relation.name)
+    });
+    Ok(())
+}
+
+fn used_relation_names(program: &ProgramSpec) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for derived in &program.derived {
+        match &derived.semantics {
+            DerivedSemanticsSpec::Scalar { expr } => {
+                collect_scalar_relation_names(expr, &mut names);
+            }
+            DerivedSemanticsSpec::Judgment { expr } => {
+                collect_judgment_relation_names(expr, &mut names);
+            }
+        }
+    }
+    names
+}
+
+fn collect_scalar_relation_names(expr: &ScalarExprSpec, names: &mut HashSet<String>) {
+    match expr {
+        ScalarExprSpec::Literal { .. }
+        | ScalarExprSpec::Input { .. }
+        | ScalarExprSpec::Derived { .. }
+        | ScalarExprSpec::PeriodStart
+        | ScalarExprSpec::PeriodEnd => {}
+        ScalarExprSpec::InputOrElse { default: _, .. } => {}
+        ScalarExprSpec::ParameterLookup { index, .. }
+        | ScalarExprSpec::Ceil { value: index }
+        | ScalarExprSpec::Floor { value: index } => {
+            collect_scalar_relation_names(index, names);
+        }
+        ScalarExprSpec::Add { items }
+        | ScalarExprSpec::Max { items }
+        | ScalarExprSpec::Min { items } => {
+            for item in items {
+                collect_scalar_relation_names(item, names);
+            }
+        }
+        ScalarExprSpec::Sub { left, right }
+        | ScalarExprSpec::Mul { left, right }
+        | ScalarExprSpec::Div { left, right } => {
+            collect_scalar_relation_names(left, names);
+            collect_scalar_relation_names(right, names);
+        }
+        ScalarExprSpec::DateAddDays { date, days } => {
+            collect_scalar_relation_names(date, names);
+            collect_scalar_relation_names(days, names);
+        }
+        ScalarExprSpec::DaysBetween { from, to } => {
+            collect_scalar_relation_names(from, names);
+            collect_scalar_relation_names(to, names);
+        }
+        ScalarExprSpec::CountRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            names.insert(relation.clone());
+            if let Some(where_clause) = where_clause {
+                collect_judgment_relation_names(where_clause, names);
+            }
+        }
+        ScalarExprSpec::SumRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            names.insert(relation.clone());
+            if let Some(where_clause) = where_clause {
+                collect_judgment_relation_names(where_clause, names);
+            }
+        }
+        ScalarExprSpec::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_judgment_relation_names(condition, names);
+            collect_scalar_relation_names(then_expr, names);
+            collect_scalar_relation_names(else_expr, names);
+        }
+    }
+}
+
+fn collect_judgment_relation_names(expr: &JudgmentExprSpec, names: &mut HashSet<String>) {
+    match expr {
+        JudgmentExprSpec::Derived { .. } => {}
+        JudgmentExprSpec::Comparison { left, right, .. } => {
+            collect_scalar_relation_names(left, names);
+            collect_scalar_relation_names(right, names);
+        }
+        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+            for item in items {
+                collect_judgment_relation_names(item, names);
+            }
+        }
+        JudgmentExprSpec::Not { item } => {
+            collect_judgment_relation_names(item, names);
+        }
+    }
 }
 
 fn rewrite_scalar_relation_references(

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -2409,10 +2409,16 @@ fn compare_scalar(explain: &OutputValue, dense: &DenseOutputValue, row: usize) {
         (ScalarValueSpec::Bool { value }, axiom_rules_engine::model::ScalarValue::Bool(dense)) => {
             assert_eq!(*value, dense)
         }
-        (ScalarValueSpec::Integer { value }, axiom_rules_engine::model::ScalarValue::Integer(dense)) => {
+        (
+            ScalarValueSpec::Integer { value },
+            axiom_rules_engine::model::ScalarValue::Integer(dense),
+        ) => {
             assert_eq!(*value, dense)
         }
-        (ScalarValueSpec::Decimal { value }, axiom_rules_engine::model::ScalarValue::Decimal(dense)) => {
+        (
+            ScalarValueSpec::Decimal { value },
+            axiom_rules_engine::model::ScalarValue::Decimal(dense),
+        ) => {
             assert_eq!(decimal(value), dense)
         }
         (ScalarValueSpec::Text { value }, axiom_rules_engine::model::ScalarValue::Text(dense)) => {
@@ -2435,7 +2441,9 @@ fn compare_judgment(explain: &OutputValue, dense: &DenseOutputValue, row: usize)
     let dense = match values[row] {
         axiom_rules_engine::model::JudgmentOutcome::Holds => JudgmentOutcomeSpec::Holds,
         axiom_rules_engine::model::JudgmentOutcome::NotHolds => JudgmentOutcomeSpec::NotHolds,
-        axiom_rules_engine::model::JudgmentOutcome::Undetermined => JudgmentOutcomeSpec::Undetermined,
+        axiom_rules_engine::model::JudgmentOutcome::Undetermined => {
+            JudgmentOutcomeSpec::Undetermined
+        }
     };
     assert_eq!(*outcome, dense);
 }

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -37,8 +37,8 @@ rules:
 
 #[test]
 fn cli_round_trip_returns_json() {
-    let program =
-        axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC).expect("program fixture parses");
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC)
+        .expect("program fixture parses");
     let request = simple_execution_request(ExecutionMode::Fast, program);
 
     let mut child = Command::new(env!("CARGO_BIN_EXE_axiom-rules-engine"))
@@ -83,8 +83,8 @@ fn cli_round_trip_returns_json() {
 
 #[test]
 fn fast_mode_matches_explain_mode_on_batch() {
-    let program =
-        axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC).expect("program fixture parses");
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC)
+        .expect("program fixture parses");
     let period = simple_period();
     let queries = simple_queries(&period);
     let dataset = simple_dataset(&period);
@@ -495,8 +495,10 @@ fn compiled_program_artifact_round_trips_and_executes() {
 
 #[test]
 fn cli_compile_and_run_compiled_round_trip() {
-    let temp_root =
-        std::env::temp_dir().join(format!("axiom-rules-engine-compile-test-{}", std::process::id()));
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-compile-test-{}",
+        std::process::id()
+    ));
     std::fs::create_dir_all(&temp_root).expect("temp dir created");
     let program_path = temp_root.join("rules.yaml");
     let artifact_path = temp_root.join("rules.compiled.json");

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -136,6 +136,25 @@ rules:
 }
 
 #[test]
+fn rulespec_source_metadata_allows_quoted_phrases() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: snap_household_food_contribution_rate
+    kind: parameter
+    dtype: Rate
+    source: 7 USC 2017(a), "30 per centum"
+    versions:
+      - effective_from: 2008-10-01
+        formula: "0.30"
+"#;
+
+    let artifact = CompiledProgramArtifact::from_rulespec_str(rulespec).expect("RuleSpec compiles");
+
+    assert_eq!(artifact.program.parameters.len(), 1);
+}
+
+#[test]
 fn rulespec_lowers_indexed_parameter_tables_and_lookup_syntax() {
     let rulespec = r#"
 format: rulespec/v1

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -1,7 +1,9 @@
 use axiom_rules_engine::api::{
     ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
 };
-use axiom_rules_engine::compile::{CompileError, CompiledProgramArtifact, compile_program_file_to_json};
+use axiom_rules_engine::compile::{
+    CompileError, CompiledProgramArtifact, compile_program_file_to_json,
+};
 use axiom_rules_engine::rulespec::{RuleSpecError, lower_rulespec_str};
 use axiom_rules_engine::spec::{
     DatasetSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, ScalarValueSpec,
@@ -122,7 +124,8 @@ rules:
         program
             .relations
             .iter()
-            .any(|r| r.name == "member_of_household")
+            .any(|r| r.name
+                == "us-tx:policies/hhsc/snap/overlay-subset#relation.member_of_household")
     );
     assert!(
         artifact
@@ -674,7 +677,10 @@ rules:
     else {
         panic!("expected judgment output");
     };
-    assert_eq!(*outcome, axiom_rules_engine::spec::JudgmentOutcomeSpec::Holds);
+    assert_eq!(
+        *outcome,
+        axiom_rules_engine::spec::JudgmentOutcomeSpec::Holds
+    );
 
     let _ = fs::remove_dir_all(root);
 }
@@ -765,7 +771,10 @@ rules:
     else {
         panic!("expected judgment output");
     };
-    assert_eq!(*outcome, axiom_rules_engine::spec::JudgmentOutcomeSpec::Holds);
+    assert_eq!(
+        *outcome,
+        axiom_rules_engine::spec::JudgmentOutcomeSpec::Holds
+    );
 
     let _ = fs::remove_dir_all(root);
 }
@@ -838,8 +847,7 @@ rules:
         start: "2026-01-01".parse().expect("valid date"),
         end: "2026-12-31".parse().expect("valid date"),
     };
-    let output_id =
-        "us:statutes/26/25A#american_opportunity_credit_before_phaseout".to_string();
+    let output_id = "us:statutes/26/25A#american_opportunity_credit_before_phaseout".to_string();
 
     let response = execute_request(ExecutionRequest {
         mode: ExecutionMode::Explain,
@@ -881,8 +889,7 @@ rules:
                 },
             ],
             relations: vec![axiom_rules_engine::spec::RelationRecordSpec {
-                name: "us:statutes/26/25A#relation.education_credit_member_of_tax_unit"
-                    .to_string(),
+                name: "us:statutes/26/25A#relation.education_credit_member_of_tax_unit".to_string(),
                 tuple: vec!["student-1".to_string(), "tax-unit-1".to_string()],
                 interval: IntervalSpec {
                     start: period.start,
@@ -909,6 +916,143 @@ rules:
         panic!("expected decimal scalar");
     };
     assert_eq!(value, "2000");
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn rulespec_namespaces_same_named_relations_by_origin_target() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("axiom-rules-engine-test-{nonce}"));
+    let first_file = root.join("rulespec-us/statutes/26/24/h.yaml");
+    let second_file = root.join("rulespec-us/statutes/26/63/c.yaml");
+    let program_file = root.join("program.yaml");
+    fs::create_dir_all(first_file.parent().expect("rules file has parent"))
+        .expect("create first rules dir");
+    fs::create_dir_all(second_file.parent().expect("rules file has parent"))
+        .expect("create second rules dir");
+    fs::write(
+        &first_file,
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: ctc_member_count
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(member_of_tax_unit)
+"#,
+    )
+    .expect("write first RuleSpec");
+    fs::write(
+        &second_file,
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: standard_deduction_member_count
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(member_of_tax_unit)
+"#,
+    )
+    .expect("write second RuleSpec");
+    fs::write(
+        &program_file,
+        r#"
+format: rulespec/v1
+imports:
+  - us:statutes/26/24/h
+  - us:statutes/26/63/c
+rules: []
+"#,
+    )
+    .expect("write program RuleSpec");
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_file(&program_file).expect("RuleSpec compiles");
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::TaxYear,
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-12-31".parse().expect("valid date"),
+    };
+    let ctc_output = "us:statutes/26/24/h#ctc_member_count".to_string();
+    let standard_deduction_output =
+        "us:statutes/26/63/c#standard_deduction_member_count".to_string();
+
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program,
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![
+                axiom_rules_engine::spec::RelationRecordSpec {
+                    name: "us:statutes/26/24/h#relation.member_of_tax_unit".to_string(),
+                    tuple: vec!["child-1".to_string(), "tax-unit-1".to_string()],
+                    interval: IntervalSpec {
+                        start: period.start,
+                        end: period.end,
+                    },
+                },
+                axiom_rules_engine::spec::RelationRecordSpec {
+                    name: "us:statutes/26/63/c#relation.member_of_tax_unit".to_string(),
+                    tuple: vec!["head-1".to_string(), "tax-unit-1".to_string()],
+                    interval: IntervalSpec {
+                        start: period.start,
+                        end: period.end,
+                    },
+                },
+            ],
+        },
+        queries: vec![ExecutionQuery {
+            entity_id: "tax-unit-1".to_string(),
+            period,
+            outputs: vec![ctc_output.clone(), standard_deduction_output.clone()],
+        }],
+    })
+    .expect("same-named relation references execute");
+
+    let OutputValue::Scalar {
+        value: ScalarValueSpec::Integer { value: ctc_count },
+        ..
+    } = response.results[0]
+        .outputs
+        .get(&ctc_output)
+        .expect("ctc member count output")
+    else {
+        panic!("expected integer scalar");
+    };
+    let OutputValue::Scalar {
+        value: ScalarValueSpec::Integer {
+            value: standard_deduction_count,
+        },
+        ..
+    } = response.results[0]
+        .outputs
+        .get(&standard_deduction_output)
+        .expect("standard deduction member count output")
+    else {
+        panic!("expected integer scalar");
+    };
+    assert_eq!(*ctc_count, 1);
+    assert_eq!(*standard_deduction_count, 1);
 
     let _ = fs::remove_dir_all(root);
 }

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -1058,6 +1058,115 @@ rules: []
 }
 
 #[test]
+fn rulespec_rejects_namespaced_relation_arity_mismatch() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("axiom-rules-engine-test-{nonce}"));
+    let rules_file = root.join("rulespec-us/statutes/26/63/c.yaml");
+    fs::create_dir_all(rules_file.parent().expect("rules file has parent"))
+        .expect("create rules dir");
+    fs::write(
+        &rules_file,
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 1
+  - name: standard_deduction_member_count
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(member_of_tax_unit)
+"#,
+    )
+    .expect("write RuleSpec");
+
+    let error = CompiledProgramArtifact::from_rulespec_file(&rules_file)
+        .expect_err("relation arity mismatch should be rejected");
+    assert!(
+        error
+            .to_string()
+            .contains("us:statutes/26/63/c#relation.member_of_tax_unit"),
+        "{error}"
+    );
+    assert!(
+        error.to_string().contains("conflicting arities 2 and 1"),
+        "{error}"
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn rulespec_keeps_unscoped_inferred_relation_when_import_uses_same_short_name() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("axiom-rules-engine-test-{nonce}"));
+    let imported_file = root.join("rulespec-us/statutes/26/63/c.yaml");
+    let program_file = root.join("program.yaml");
+    fs::create_dir_all(imported_file.parent().expect("rules file has parent"))
+        .expect("create rules dir");
+    fs::write(
+        &imported_file,
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 2
+"#,
+    )
+    .expect("write imported RuleSpec");
+    fs::write(
+        &program_file,
+        r#"
+format: rulespec/v1
+imports:
+  - us:statutes/26/63/c
+rules:
+  - name: local_member_count
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(member_of_tax_unit)
+"#,
+    )
+    .expect("write program RuleSpec");
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_file(&program_file).expect("RuleSpec compiles");
+    assert!(
+        artifact
+            .program
+            .relations
+            .iter()
+            .any(|relation| relation.name == "us:statutes/26/63/c#relation.member_of_tax_unit")
+    );
+    assert!(
+        artifact
+            .program
+            .relations
+            .iter()
+            .any(|relation| relation.name == "member_of_tax_unit")
+    );
+
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn rulespec_rejects_parameter_values_without_indexed_by() {
     let rulespec = r#"
 format: rulespec/v1


### PR DESCRIPTION
## Summary
- namespace data relation schemas by their RuleSpec origin target
- rewrite lowered relation aggregations to the canonical relation IDs
- add a regression for two modules that both define member_of_tax_unit

## Validation
- cargo test
- cargo test --test rulespec
- cargo build

This fixes relation collisions such as 26/24/h#relation.member_of_tax_unit and 26/63/c#relation.member_of_tax_unit being merged into one runtime relation.